### PR TITLE
允许为视频添加封面图

### DIFF
--- a/node-proxy/src/encNameRouter.js
+++ b/node-proxy/src/encNameRouter.js
@@ -37,6 +37,30 @@ encNameRouter.all('/api/fs/list', async (ctx, next) => {
         fileInfo.name = convertShowName(passwdInfo.password, passwdInfo.encType, fileInfo.name)
       }
     }
+
+    const coverNameMap = {} //根据不含后缀的视频文件名找到对应的含后缀的封面文件名
+    const omitNames = [] //用于隐藏封面文件
+    const { path } = JSON.parse(ctx.req.reqBody)
+    result.data.content.forEach((fileInfo) => {
+      if (fileInfo.is_dir) {
+        return
+      }
+      if (fileInfo.type === 5) {
+        coverNameMap[fileInfo.name.split('.')[0]] = fileInfo.name
+      }
+    })
+    result.data.content.forEach((fileInfo) => {
+      if (fileInfo.is_dir) {
+        return
+      }
+      const coverName = coverNameMap[fileInfo.name.split('.')[0]]
+      if (fileInfo.type === 2 && coverName) {
+        omitNames.push(coverName)
+        fileInfo.thumb = `/d${path}/${coverName}`
+      }
+    })
+    //不展示封面文件，也许可以添加个配置让用户选择是否展示封面源文件
+    result.data.content = result.data.content.filter((fileInfo) => !omitNames.includes(fileInfo.name))
   }
 })
 


### PR DESCRIPTION
要求：原视频与封面视频具有相同的文件名，如
![截图_20240726142754](https://github.com/user-attachments/assets/b25d8d71-adeb-45aa-89b9-620790b17ff2)
此时加密后有相同前缀，后缀不同是因为视频和图片的扩展名不同
![截图_20240726142919](https://github.com/user-attachments/assets/06796dc1-e5d8-4b2e-859f-0ca5b9e72b75)
在网格视图即可预览
![截图_20240726143243](https://github.com/user-attachments/assets/dd565ef4-8018-44f6-b8aa-b286f5a471da)
目前写死了隐藏封面文件，也许可以加个配置让用户选择是否隐藏

注意若文件夹内视频较多时，要压缩一下封面文件避免体积过大，否则打开文件夹时需要消耗大量资源解密封面图，造成一段时间内播放卡顿