### PR TITLE
feat: add WinZip AES CTR zip encryption

### DIFF
--- a/enc-webui/src/views/setting-alist/index.vue
+++ b/enc-webui/src/views/setting-alist/index.vue
@@ -26,6 +26,7 @@
             <!-- <el-radio label="mix" border>MIX</el-radio> -->
             <el-radio label="aesctr" border>AES-CTR</el-radio>
             <el-radio label="rc4" border>RC4</el-radio>
+            <el-radio label="winzip-aes-ctr" border>WinZip-AES-CTR</el-radio>
           </el-radio-group>
           开启
           <el-switch v-model="item.enable" class="ml-2" style="--el-switch-on-color: #13ce66; --el-switch-off-color: #ff4949" />

--- a/enc-webui/src/views/setting-alist/index.vue
+++ b/enc-webui/src/views/setting-alist/index.vue
@@ -41,6 +41,10 @@
           <!-- 后缀
           <el-input v-model="item.encSuffix" style="max-width: 150px; margin-left: 10px" placeholder="默认原文件名后缀" /> -->
         </el-form-item>
+        <el-form-item v-if="item.encType === 'winzip-aes-ctr'" label="ZIP缓存">
+          自动
+          <el-switch v-model="item.zipAutoCache" class="ml-2" style="margin-right: 10px; --el-switch-on-color: #13ce66; --el-switch-off-color: #ff4949" />
+        </el-form-item>
         <el-form-item label="备注">
           <el-input v-model="item.describe" style="max-width: 260px; margin-right: 10px" placeholder="备注描述" />
         </el-form-item>
@@ -145,6 +149,7 @@ const alistConfigForm = reactive({
       encType: 'aesctr',
       enable: false,
       encName: false, // encrypt file name
+      zipAutoCache: false,
       encSuffix: '', //
       describe: 'my video',
       encPath: '333'
@@ -159,6 +164,7 @@ const addPasswd = () => {
     password: '123456',
     encType: 'aesctr',
     enable: true,
+    zipAutoCache: false,
     describe: 'my video',
     encPath: '/aliyun/encrypt/*'
   })

--- a/enc-webui/src/views/setting-webdav/index.vue
+++ b/enc-webui/src/views/setting-webdav/index.vue
@@ -33,6 +33,7 @@
               <!-- <el-radio label="mix" border>MIX</el-radio> -->
               <el-radio label="rc4" border>RC4</el-radio>
               <el-radio label="aesctr" border>AES-CTR(新)</el-radio>
+              <el-radio label="winzip-aes-ctr" border>WinZip-AES-CTR</el-radio>
             </el-radio-group>
             开启
             <el-switch v-model="item.enable" class="ml-2" style="--el-switch-on-color: #13ce66; --el-switch-off-color: #ff4949" />

--- a/enc-webui/src/views/setting-webdav/index.vue
+++ b/enc-webui/src/views/setting-webdav/index.vue
@@ -51,6 +51,14 @@
               <!-- 后缀
               <el-input v-model="item.encSuffix" style="max-width: 150px; margin-left: 10px" placeholder="默认原文件名后缀" /> -->
             </el-form-item>
+            <el-form-item v-if="item.encType === 'winzip-aes-ctr'" label="ZIP缓存">
+              自动
+              <el-switch
+                v-model="item.zipAutoCache"
+                class="ml-2"
+                style="margin-right: 10px; --el-switch-on-color: #13ce66; --el-switch-off-color: #ff4949"
+              />
+            </el-form-item>
             <el-form-item label="备注">
               <el-input v-model="item.describe" style="max-width: 260px; margin-right: 10px" placeholder="备注描述" />
             </el-form-item>
@@ -120,6 +128,7 @@ const configTemp = {
       encType: 'aesctr',
       enable: false,
       encName: false, // encrypt file name
+      zipAutoCache: false,
       encSuffix: '', //
       describe: 'my video',
       encPath: '/aliyun/encrypt/*'
@@ -136,6 +145,7 @@ const addPasswd = () => {
     password: '123456',
     encType: 'aesctr',
     enable: true,
+    zipAutoCache: false,
     describe: 'my video',
     encPath: '/dav/encrypt/*'
   })

--- a/node-proxy/app.js
+++ b/node-proxy/app.js
@@ -19,6 +19,7 @@ import WinZipAesZip, {
   deserializeWinZipAesZipInfo,
   getMimeByName,
   isWinZipAesEncType,
+  parseManagedWinZipAesZipInfoFromRemote,
   parseWinZipAesZipInfoFromRemote,
   prepareWinZipAesDownloadRequest,
   serializeWinZipAesZipInfo,
@@ -38,7 +39,9 @@ import { logger } from '@/common/logger'
 import {
   cacheExternalWinZipAesZipInfo,
   cacheExternalWinZipAesZipNegative,
+  cacheManagedWinZipAesZipInfo,
   getWinZipAesZipProbeCache,
+  isUsableWinZipAesZipInfoCache,
 } from '@/utils/winZipAesZipCache'
 
 async function sleep(time) {
@@ -94,6 +97,31 @@ async function prepareExternalWinZipAesZipInfo(request, fileInfo, parseUrl, head
     await cacheExternalWinZipAesZipNegative(fileInfo, e)
     return null
   }
+}
+
+async function prepareManagedWinZipAesZipInfo(request, passwdInfo, fileInfo, parseUrl, headers, options = {}) {
+  const enableZipInfoCache = passwdInfo.zipInfoCache !== false
+  if (enableZipInfoCache) {
+    const cachedFileInfo = (await getFileInfo(fileInfo.path)) || (await getFileInfo(encodeURIComponent(fileInfo.path)))
+    if (isUsableWinZipAesZipInfoCache(cachedFileInfo, fileInfo.size)) {
+      return cachedFileInfo
+    }
+  }
+  let zipInfo
+  try {
+    zipInfo = await parseManagedWinZipAesZipInfoFromRemote(parseUrl, headers, fileInfo.size, options)
+  } catch (e) {
+    zipInfo = await parseWinZipAesZipInfoFromRemote(parseUrl, headers, fileInfo.size, options)
+  }
+  const nextFileInfo = {
+    ...fileInfo,
+    plainSize: zipInfo.plainSize,
+    zipInfo: serializeWinZipAesZipInfo(zipInfo),
+  }
+  if (!enableZipInfoCache) {
+    return nextFileInfo
+  }
+  return await cacheManagedWinZipAesZipInfo(nextFileInfo, zipInfo)
 }
 
 function applyWinZipAesHeadResponse(response, request) {
@@ -427,7 +455,22 @@ proxyRouter.all('/api/fs/get', bodyparserMw, async (ctx, next) => {
         }
         zipInfo = deserializeWinZipAesZipInfo(cachedOrParsed.zipInfo)
       } else {
-        zipInfo = await parseWinZipAesZipInfoFromRemote(result.data.raw_url, ctx.req.headers, remoteFileSize, { stripAuth: true })
+        const cachedOrParsed = await prepareManagedWinZipAesZipInfo(
+          ctx.req,
+          passwdInfo,
+          {
+            ...result.data,
+            path,
+            name: path.split('/').pop(),
+            is_dir: false,
+            size: remoteFileSize,
+            zipVirtualName: decodeURIComponent((ctx.req.encVirtualPath || path).split('/').pop() || ''),
+          },
+          result.data.raw_url,
+          ctx.req.headers,
+          { stripAuth: true }
+        )
+        zipInfo = deserializeWinZipAesZipInfo(cachedOrParsed.zipInfo)
       }
       result.data.size = zipInfo.plainSize
     }

--- a/node-proxy/app.js
+++ b/node-proxy/app.js
@@ -35,6 +35,11 @@ import { cacheFileInfo, getFileInfo } from '@/dao/fileDao'
 import { getWebdavFileInfo } from '@/utils/webdavClient'
 import staticServer from 'koa-static'
 import { logger } from '@/common/logger'
+import {
+  cacheExternalWinZipAesZipInfo,
+  cacheExternalWinZipAesZipNegative,
+  getWinZipAesZipProbeCache,
+} from '@/utils/winZipAesZipCache'
 
 async function sleep(time) {
   return new Promise((resolve) => {
@@ -72,6 +77,23 @@ async function prepareWinZipAesDecrypt(request, passwdInfo, zipSize, rangeHeader
   const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, zipInfo.plainSize, { zipInfo })
   await flowEnc.setPosition(request.zipCipherStart || 0)
   return flowEnc
+}
+
+async function prepareExternalWinZipAesZipInfo(request, fileInfo, parseUrl, headers, options = {}) {
+  const probeCache = await getWinZipAesZipProbeCache(fileInfo.path, fileInfo.size)
+  if (probeCache.type === 'hit') {
+    return probeCache.fileInfo
+  }
+  if (probeCache.type === 'negative') {
+    return null
+  }
+  try {
+    const zipInfo = await parseWinZipAesZipInfoFromRemote(parseUrl, headers, fileInfo.size, options)
+    return await cacheExternalWinZipAesZipInfo(fileInfo, zipInfo)
+  } catch (e) {
+    await cacheExternalWinZipAesZipNegative(fileInfo, e)
+    return null
+  }
 }
 
 function applyWinZipAesHeadResponse(response, request) {
@@ -289,16 +311,29 @@ async function proxyHandle(ctx, next) {
     }
     let flowEnc = null
     if (isWinZipAesEncType(passwdInfo.encType)) {
-      const cachedZipInfo = deserializeWinZipAesZipInfo(fileInfo && fileInfo.zipInfo)
-      try {
-        flowEnc = await prepareWinZipAesDecrypt(request, passwdInfo, request.fileSize, range, cachedZipInfo)
-      } catch (e) {
-        if (request.isExternalZipCandidate && !(fileInfo && fileInfo.externalZip)) {
-          logger.info('@@ordinary zip passthrough:', filePath, e.message)
+      if (request.isExternalZipCandidate && !(fileInfo && fileInfo.externalZip)) {
+        const externalFileInfo = await prepareExternalWinZipAesZipInfo(
+          request,
+          fileInfo || {
+            path: filePath,
+            name: path.basename(filePath),
+            is_dir: false,
+            size: request.fileSize,
+            zipVirtualName: path.basename(filePath),
+          },
+          request.urlAddr,
+          request.headers
+        )
+        if (!externalFileInfo || !externalFileInfo.zipInfo) {
+          logger.info('@@ordinary zip passthrough:', filePath)
           return await httpProxy(request, response)
         }
-        throw e
+        fileInfo = externalFileInfo
+        request.isExternalZip = true
+        request.zipVirtualName = externalFileInfo.zipInfo && externalFileInfo.zipInfo.innerName
       }
+      const cachedZipInfo = deserializeWinZipAesZipInfo(fileInfo && fileInfo.zipInfo)
+      flowEnc = await prepareWinZipAesDecrypt(request, passwdInfo, request.fileSize, range, cachedZipInfo)
       if (
         fileInfo &&
         request.zipInfo &&
@@ -370,14 +405,29 @@ proxyRouter.all('/api/fs/get', bodyparserMw, async (ctx, next) => {
     const remoteFileSize = result.data.size
     let zipInfo = null
     if (isWinZipAesEncType(passwdInfo.encType)) {
-      try {
-        zipInfo = await parseWinZipAesZipInfoFromRemote(result.data.raw_url, ctx.req.headers, remoteFileSize, { stripAuth: true })
-      } catch (e) {
-        if (ctx.req.isExternalZipCandidate) {
+      if (ctx.req.isExternalZip && ctx.req.cachedExternalZipInfo) {
+        zipInfo = deserializeWinZipAesZipInfo(ctx.req.cachedExternalZipInfo)
+      } else if (ctx.req.isExternalZipCandidate) {
+        const cachedOrParsed = await prepareExternalWinZipAesZipInfo(
+          ctx.req,
+          {
+            path,
+            name: path.split('/').pop(),
+            is_dir: false,
+            size: remoteFileSize,
+            zipVirtualName: path.split('/').pop(),
+          },
+          result.data.raw_url,
+          ctx.req.headers,
+          { stripAuth: true }
+        )
+        if (!cachedOrParsed || !cachedOrParsed.zipInfo) {
           ctx.body = result
           return
         }
-        throw e
+        zipInfo = deserializeWinZipAesZipInfo(cachedOrParsed.zipInfo)
+      } else {
+        zipInfo = await parseWinZipAesZipInfoFromRemote(result.data.raw_url, ctx.req.headers, remoteFileSize, { stripAuth: true })
       }
       result.data.size = zipInfo.plainSize
     }

--- a/node-proxy/app.js
+++ b/node-proxy/app.js
@@ -15,9 +15,16 @@ import path from 'path'
 import { httpProxy, httpClient } from '@/utils/httpClient'
 import bodyparser from 'koa-bodyparser'
 import FlowEnc from '@/utils/flowEnc'
+import WinZipAesZip, {
+  deserializeWinZipAesZipInfo,
+  isWinZipAesEncType,
+  parseWinZipAesZipInfoFromRemote,
+  prepareWinZipAesDownloadRequest,
+  serializeWinZipAesZipInfo,
+} from '@/utils/winZipAesZip'
 import levelDB from '@/utils/levelDB'
 import { webdavServer, alistServer, port, version } from '@/config'
-import { pathExec, pathFindPasswd } from '@/utils/commonUtil'
+import { convertRealName, pathExec, pathFindPasswd } from '@/utils/commonUtil'
 import globalHandle from '@/middleware/globalHandle'
 import encApiRouter from '@/router'
 import encNameRouter from '@/encNameRouter'
@@ -27,7 +34,6 @@ import { cacheFileInfo, getFileInfo } from '@/dao/fileDao'
 import { getWebdavFileInfo } from '@/utils/webdavClient'
 import staticServer from 'koa-static'
 import { logger } from '@/common/logger'
-import { encodeName } from '@/utils/commonUtil'
 
 async function sleep(time) {
   return new Promise((resolve) => {
@@ -35,6 +41,39 @@ async function sleep(time) {
       resolve()
     }, time || 3000)
   })
+}
+
+function getRangeStart(range) {
+  return range ? Number(String(range).replace('bytes=', '').split('-')[0] || 0) : 0
+}
+
+function getAListFileTypeByName(fileName = '') {
+  const ext = path.extname(String(fileName).split('?')[0]).toLowerCase()
+  if (['.mp4', '.m4v', '.webm', '.mkv', '.avi', '.mov', '.flv', '.wmv', '.ts', '.mpg', '.mpeg'].includes(ext)) return 2
+  if (['.mp3', '.m4a', '.aac', '.flac', '.wav', '.ogg'].includes(ext)) return 3
+  if (['.txt', '.md', '.json', '.js', '.ts', '.css', '.html', '.xml', '.log'].includes(ext)) return 4
+  if (['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.svg'].includes(ext)) return 5
+  return 0
+}
+
+function setWinZipAesUploadSize(request, passwdInfo, plainSize, originalName) {
+  if (!isWinZipAesEncType(passwdInfo.encType)) return
+  const packageSize = WinZipAesZip.packageSize(plainSize, {
+    originalName,
+  })
+  request.headers['content-length'] = String(packageSize)
+  delete request.headers['x-expected-entity-length']
+}
+
+async function prepareWinZipAesDecrypt(request, passwdInfo, zipSize, rangeHeader, cachedZipInfo = null) {
+  const zipInfo =
+    cachedZipInfo ||
+    (await parseWinZipAesZipInfoFromRemote(request.urlAddr, request.headers, zipSize))
+  request.zipVirtualName = request.zipVirtualName || path.basename(decodeURIComponent(request.url.split('?')[0] || zipInfo.innerName))
+  prepareWinZipAesDownloadRequest(request, zipInfo, rangeHeader)
+  const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, zipInfo.plainSize, { zipInfo })
+  await flowEnc.setPosition(request.zipCipherStart || 0)
+  return flowEnc
 }
 
 const proxyRouter = new Router()
@@ -64,14 +103,10 @@ proxyRouter.all('/redirect/:key', async (ctx) => {
     ctx.body = 'no found'
     return
   }
-  const { passwdInfo, redirectUrl, fileSize } = data
+  const { passwdInfo, redirectUrl, fileSize, virtualName, zipInfo: cachedZipInfoData } = data
   // 要定位请求文件的位置 bytes=98304-
   const range = request.headers.range
-  const start = range ? range.replace('bytes=', '').split('-')[0] * 1 : 0
-  const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, fileSize)
-  if (start) {
-    await flowEnc.setPosition(start)
-  }
+  const start = getRangeStart(range)
   // 设置请求地址和是否要解密
   const decode = ctx.query.decode
   // 修改百度头
@@ -90,9 +125,20 @@ proxyRouter.all('/redirect/:key', async (ctx) => {
   delete request.headers.authorization
 
   // 默认判断路径来识别是否要解密，如果有decode参数，那么则按decode来处理，这样可以让用户手动处理是否解密？(那还不如直接在alist下载)
-  let decryptTransform = passwdInfo.enable && pathExec(passwdInfo.encPath, request.url) ? flowEnc.decryptTransform() : null
-  if (decode) {
-    decryptTransform = decode !== '0' ? flowEnc.decryptTransform() : null
+  const shouldDecode = decode ? decode !== '0' : passwdInfo.enable && pathExec(passwdInfo.encPath, request.url)
+  let decryptTransform = null
+  request.zipVirtualName = virtualName
+  if (shouldDecode) {
+    let flowEnc = null
+    if (isWinZipAesEncType(passwdInfo.encType)) {
+      flowEnc = await prepareWinZipAesDecrypt(request, passwdInfo, fileSize, range, deserializeWinZipAesZipInfo(cachedZipInfoData))
+    } else {
+      flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, fileSize)
+      if (start) {
+        await flowEnc.setPosition(start)
+      }
+    }
+    decryptTransform = flowEnc.decryptTransform()
   }
   // 请求实际服务资源
   await httpProxy(request, response, null, decryptTransform)
@@ -149,7 +195,9 @@ async function proxyHandle(ctx, next) {
     if (request.fileSize === 0) {
       return await httpProxy(request, response)
     }
-    const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, request.fileSize)
+    const originalName = path.basename(decodeURIComponent(request.url.split('?')[0] || ''))
+    setWinZipAesUploadSize(request, passwdInfo, request.fileSize, originalName)
+    const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, request.fileSize, { originalName })
     return await httpProxy(request, response, flowEnc.encryptTransform())
   }
   // 如果是下载文件，那么就进行判断是否解密
@@ -171,10 +219,8 @@ async function proxyHandle(ctx, next) {
 
     if (fileInfo === null) {
       const rawFileName = decodeURIComponent(path.basename(filePath));
-      const ext = path.extname(rawFileName);
       const encodedRawFileName = encodeURIComponent(rawFileName);
-      const encFileName = encodeName(passwdInfo.password, passwdInfo.encType, rawFileName);
-      const newFileName = encFileName + ext;
+      const newFileName = convertRealName(passwdInfo.password, passwdInfo.encType, rawFileName);
     
       filePath = filePath.replace(encodedRawFileName, newFileName);
       request.urlAddr = request.urlAddr.replace(encodedRawFileName, newFileName);
@@ -204,9 +250,14 @@ async function proxyHandle(ctx, next) {
       // 说明不用加密
       return await httpProxy(request, response)
     }
-    const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, request.fileSize)
-    if (start) {
-      await flowEnc.setPosition(start)
+    let flowEnc = null
+    if (isWinZipAesEncType(passwdInfo.encType)) {
+      flowEnc = await prepareWinZipAesDecrypt(request, passwdInfo, request.fileSize, range)
+    } else {
+      flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, request.fileSize)
+      if (start) {
+        await flowEnc.setPosition(start)
+      }
     }
     return await httpProxy(request, response, null, flowEnc.decryptTransform())
   }
@@ -246,15 +297,35 @@ proxyRouter.all('/api/fs/get', bodyparserMw, async (ctx, next) => {
   const { headers } = ctx.req
   const { passwdInfo } = pathFindPasswd(alistServer.passwdList, path)
 
-  if (passwdInfo) {
+  if (passwdInfo && result.code === 200 && result.data && result.data.raw_url) {
     // 修改返回的响应，匹配到要解密，就302跳转到本服务上进行代理流量
     logger.info('@@getFile ', path, ctx.req.reqBody, result)
+    const remoteFileSize = result.data.size
+    let zipInfo = null
+    if (isWinZipAesEncType(passwdInfo.encType)) {
+      zipInfo = await parseWinZipAesZipInfoFromRemote(result.data.raw_url, ctx.req.headers, remoteFileSize, { stripAuth: true })
+      result.data.size = zipInfo.plainSize
+    }
     const key = crypto.randomUUID()
-    await levelDB.setExpire(key, { redirectUrl: result.data.raw_url, passwdInfo, fileSize: result.data.size }, 60 * 60 * 72) // 缓存起来，默认3天，足够下载和观看了
+    const virtualName = decodeURIComponent((ctx.req.encVirtualPath || path).split('/').pop() || '')
+    await levelDB.setExpire(
+      key,
+      {
+        redirectUrl: result.data.raw_url,
+        passwdInfo,
+        fileSize: remoteFileSize,
+        virtualName,
+        zipInfo: serializeWinZipAesZipInfo(zipInfo),
+      },
+      60 * 60 * 72
+    ) // 缓存起来，默认3天，足够下载和观看了
     result.data.raw_url = `${
       headers.origin || (headers['x-forwarded-proto'] || ctx.protocol) + '://' + ctx.req.selfHost
     }/redirect/${key}?decode=1&lastUrl=${encodeURIComponent(path)}`
-    if (result.data.provider === 'AliyundriveOpen') result.data.provider = 'Local'
+    if (virtualName) {
+      result.data.type = getAListFileTypeByName(virtualName)
+    }
+    if (isWinZipAesEncType(passwdInfo.encType) || result.data.provider === 'AliyundriveOpen') result.data.provider = 'Local'
   }
   ctx.body = result
 })
@@ -301,7 +372,9 @@ proxyRouter.put('/api/fs/put-back', async (ctx, next) => {
   const uploadPath = headers['file-path'] ? decodeURIComponent(headers['file-path']) : '/-'
   const { passwdInfo } = pathFindPasswd(webdavConfig.passwdList, uploadPath)
   if (passwdInfo) {
-    const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, request.fileSize)
+    const originalName = path.basename(uploadPath)
+    setWinZipAesUploadSize(request, passwdInfo, request.fileSize, originalName)
+    const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, request.fileSize, { originalName })
     return await httpProxy(ctx.req, ctx.res, flowEnc.encryptTransform())
   }
   return await httpProxy(ctx.req, ctx.res)

--- a/node-proxy/app.js
+++ b/node-proxy/app.js
@@ -17,6 +17,7 @@ import bodyparser from 'koa-bodyparser'
 import FlowEnc from '@/utils/flowEnc'
 import WinZipAesZip, {
   deserializeWinZipAesZipInfo,
+  getMimeByName,
   isWinZipAesEncType,
   parseWinZipAesZipInfoFromRemote,
   prepareWinZipAesDownloadRequest,
@@ -66,14 +67,30 @@ function setWinZipAesUploadSize(request, passwdInfo, plainSize, originalName) {
 }
 
 async function prepareWinZipAesDecrypt(request, passwdInfo, zipSize, rangeHeader, cachedZipInfo = null) {
+  const validCachedZipInfo =
+    cachedZipInfo && Number(cachedZipInfo.totalSize) === Number(zipSize) ? cachedZipInfo : null
   const zipInfo =
-    cachedZipInfo ||
+    validCachedZipInfo ||
     (await parseWinZipAesZipInfoFromRemote(request.urlAddr, request.headers, zipSize))
   request.zipVirtualName = request.zipVirtualName || path.basename(decodeURIComponent(request.url.split('?')[0] || zipInfo.innerName))
   prepareWinZipAesDownloadRequest(request, zipInfo, rangeHeader)
   const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, zipInfo.plainSize, { zipInfo })
   await flowEnc.setPosition(request.zipCipherStart || 0)
   return flowEnc
+}
+
+function applyWinZipAesHeadResponse(response, request) {
+  const { zipInfo, zipPlainRange } = request
+  if (!zipInfo || !zipPlainRange) return
+  response.statusCode = zipPlainRange.hasRange ? 206 : 200
+  if (zipPlainRange.hasRange) {
+    response.setHeader('content-range', `bytes ${zipPlainRange.start}-${zipPlainRange.end}/${zipInfo.plainSize}`)
+  } else {
+    response.removeHeader('content-range')
+  }
+  response.setHeader('accept-ranges', 'bytes')
+  response.setHeader('content-length', String(Math.max(0, zipPlainRange.end - zipPlainRange.start + 1)))
+  response.setHeader('content-type', getMimeByName(request.zipVirtualName || request.url))
 }
 
 const proxyRouter = new Router()
@@ -228,6 +245,21 @@ async function proxyHandle(ctx, next) {
       fileInfo = await getFileInfo(filePath);
     }
     logger.info('@@getFileInfo:', filePath, fileInfo, request.urlAddr)
+    if (
+      request.isWebdav &&
+      fileInfo &&
+      isWinZipAesEncType(passwdInfo.encType) &&
+      Number(fileInfo.size) < 1024 &&
+      request.headers.authorization
+    ) {
+      const webdavFileInfo = await getWebdavFileInfo(request.urlAddr, request.headers.authorization)
+      logger.info('@@webdavFileInfoRefresh:', filePath, webdavFileInfo)
+      if (webdavFileInfo && webdavFileInfo.size * 1 > 0) {
+        webdavFileInfo.path = filePath
+        await cacheFileInfo(webdavFileInfo)
+        fileInfo = webdavFileInfo
+      }
+    }
     if (fileInfo) {
       request.fileSize = fileInfo.size * 1
     } else if (request.headers.authorization) {
@@ -239,9 +271,10 @@ async function proxyHandle(ctx, next) {
         webdavFileInfo.path = filePath
         // 某些get请求返回的size=0，不要缓存起来
         if (webdavFileInfo.size * 1 > 0) {
-          cacheFileInfo(webdavFileInfo)
+          await cacheFileInfo(webdavFileInfo)
         }
         request.fileSize = webdavFileInfo.size * 1
+        fileInfo = webdavFileInfo
       }
     }
     request.passwdInfo = passwdInfo
@@ -252,7 +285,27 @@ async function proxyHandle(ctx, next) {
     }
     let flowEnc = null
     if (isWinZipAesEncType(passwdInfo.encType)) {
-      flowEnc = await prepareWinZipAesDecrypt(request, passwdInfo, request.fileSize, range)
+      const cachedZipInfo = deserializeWinZipAesZipInfo(fileInfo && fileInfo.zipInfo)
+      flowEnc = await prepareWinZipAesDecrypt(request, passwdInfo, request.fileSize, range, cachedZipInfo)
+      if (
+        fileInfo &&
+        request.zipInfo &&
+        (!cachedZipInfo || Number(cachedZipInfo.totalSize) !== Number(request.fileSize))
+      ) {
+        await cacheFileInfo({
+          ...fileInfo,
+          plainSize: request.zipInfo.plainSize,
+          zipInfo: serializeWinZipAesZipInfo(request.zipInfo),
+        })
+      }
+      if (request.method.toLocaleUpperCase() === 'HEAD') {
+        applyWinZipAesHeadResponse(response, request)
+        response.end()
+        return
+      }
+      if (request.isWebdav) {
+        request.followRemoteRedirect = true
+      }
     } else {
       flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, request.fileSize)
       if (start) {

--- a/node-proxy/app.js
+++ b/node-proxy/app.js
@@ -25,7 +25,7 @@ import WinZipAesZip, {
 } from '@/utils/winZipAesZip'
 import levelDB from '@/utils/levelDB'
 import { webdavServer, alistServer, port, version } from '@/config'
-import { convertRealName, pathExec, pathFindPasswd } from '@/utils/commonUtil'
+import { convertRealName, getAListFileTypeByName, isRawZipName, pathExec, pathFindPasswd } from '@/utils/commonUtil'
 import globalHandle from '@/middleware/globalHandle'
 import encApiRouter from '@/router'
 import encNameRouter from '@/encNameRouter'
@@ -48,15 +48,6 @@ function getRangeStart(range) {
   return range ? Number(String(range).replace('bytes=', '').split('-')[0] || 0) : 0
 }
 
-function getAListFileTypeByName(fileName = '') {
-  const ext = path.extname(String(fileName).split('?')[0]).toLowerCase()
-  if (['.mp4', '.m4v', '.webm', '.mkv', '.avi', '.mov', '.flv', '.wmv', '.ts', '.mpg', '.mpeg'].includes(ext)) return 2
-  if (['.mp3', '.m4a', '.aac', '.flac', '.wav', '.ogg'].includes(ext)) return 3
-  if (['.txt', '.md', '.json', '.js', '.ts', '.css', '.html', '.xml', '.log'].includes(ext)) return 4
-  if (['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.svg'].includes(ext)) return 5
-  return 0
-}
-
 function setWinZipAesUploadSize(request, passwdInfo, plainSize, originalName) {
   if (!isWinZipAesEncType(passwdInfo.encType)) return
   const packageSize = WinZipAesZip.packageSize(plainSize, {
@@ -72,7 +63,11 @@ async function prepareWinZipAesDecrypt(request, passwdInfo, zipSize, rangeHeader
   const zipInfo =
     validCachedZipInfo ||
     (await parseWinZipAesZipInfoFromRemote(request.urlAddr, request.headers, zipSize))
-  request.zipVirtualName = request.zipVirtualName || path.basename(decodeURIComponent(request.url.split('?')[0] || zipInfo.innerName))
+  request.zipVirtualName =
+    request.zipVirtualName ||
+    (request.isExternalZip || request.isExternalZipCandidate
+      ? zipInfo.innerName
+      : path.basename(decodeURIComponent(request.url.split('?')[0] || zipInfo.innerName)))
   prepareWinZipAesDownloadRequest(request, zipInfo, rangeHeader)
   const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, zipInfo.plainSize, { zipInfo })
   await flowEnc.setPosition(request.zipCipherStart || 0)
@@ -212,7 +207,7 @@ async function proxyHandle(ctx, next) {
     if (request.fileSize === 0) {
       return await httpProxy(request, response)
     }
-    const originalName = path.basename(decodeURIComponent(request.url.split('?')[0] || ''))
+    const originalName = request.originalName || path.basename(decodeURIComponent(request.url.split('?')[0] || ''))
     setWinZipAesUploadSize(request, passwdInfo, request.fileSize, originalName)
     const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, request.fileSize, { originalName })
     return await httpProxy(request, response, flowEnc.encryptTransform())
@@ -233,16 +228,21 @@ async function proxyHandle(ctx, next) {
     }
     // 尝试获取文件信息，如果未找到相应的文件信息，则对文件名进行加密处理后重新尝试获取文件信息
     let fileInfo = await getFileInfo(filePath);
+    const requestedFileName = decodeURIComponent(path.basename(filePath))
 
     if (fileInfo === null) {
-      const rawFileName = decodeURIComponent(path.basename(filePath));
-      const encodedRawFileName = encodeURIComponent(rawFileName);
-      const newFileName = convertRealName(passwdInfo.password, passwdInfo.encType, rawFileName);
-    
-      filePath = filePath.replace(encodedRawFileName, newFileName);
-      request.urlAddr = request.urlAddr.replace(encodedRawFileName, newFileName);
-    
-      fileInfo = await getFileInfo(filePath);
+      if (!isWinZipAesEncType(passwdInfo.encType) || !requestedFileName.toLowerCase().endsWith('.zip')) {
+        const encodedRawFileName = encodeURIComponent(requestedFileName);
+        const newFileName = convertRealName(passwdInfo.password, passwdInfo.encType, requestedFileName);
+
+        filePath = filePath.replace(encodedRawFileName, newFileName);
+        request.urlAddr = request.urlAddr.replace(encodedRawFileName, newFileName);
+
+        fileInfo = await getFileInfo(filePath);
+      }
+    }
+    if (isRawZipName(passwdInfo.password, passwdInfo.encType, requestedFileName)) {
+      request.isExternalZipCandidate = true
     }
     logger.info('@@getFileInfo:', filePath, fileInfo, request.urlAddr)
     if (
@@ -262,6 +262,10 @@ async function proxyHandle(ctx, next) {
     }
     if (fileInfo) {
       request.fileSize = fileInfo.size * 1
+      if (fileInfo.externalZip) {
+        request.isExternalZip = true
+        request.zipVirtualName = fileInfo.zipInfo && fileInfo.zipInfo.innerName
+      }
     } else if (request.headers.authorization) {
       // 这里要判断是否webdav进行请求, 这里默认就是webdav请求了
       const authorization = request.headers.authorization
@@ -286,7 +290,15 @@ async function proxyHandle(ctx, next) {
     let flowEnc = null
     if (isWinZipAesEncType(passwdInfo.encType)) {
       const cachedZipInfo = deserializeWinZipAesZipInfo(fileInfo && fileInfo.zipInfo)
-      flowEnc = await prepareWinZipAesDecrypt(request, passwdInfo, request.fileSize, range, cachedZipInfo)
+      try {
+        flowEnc = await prepareWinZipAesDecrypt(request, passwdInfo, request.fileSize, range, cachedZipInfo)
+      } catch (e) {
+        if (request.isExternalZipCandidate && !(fileInfo && fileInfo.externalZip)) {
+          logger.info('@@ordinary zip passthrough:', filePath, e.message)
+          return await httpProxy(request, response)
+        }
+        throw e
+      }
       if (
         fileInfo &&
         request.zipInfo &&
@@ -296,6 +308,8 @@ async function proxyHandle(ctx, next) {
           ...fileInfo,
           plainSize: request.zipInfo.plainSize,
           zipInfo: serializeWinZipAesZipInfo(request.zipInfo),
+          externalZip: fileInfo.externalZip || request.isExternalZipCandidate,
+          zipVirtualName: fileInfo.zipVirtualName || (request.isExternalZipCandidate ? path.basename(filePath) : undefined),
         })
       }
       if (request.method.toLocaleUpperCase() === 'HEAD') {
@@ -356,18 +370,27 @@ proxyRouter.all('/api/fs/get', bodyparserMw, async (ctx, next) => {
     const remoteFileSize = result.data.size
     let zipInfo = null
     if (isWinZipAesEncType(passwdInfo.encType)) {
-      zipInfo = await parseWinZipAesZipInfoFromRemote(result.data.raw_url, ctx.req.headers, remoteFileSize, { stripAuth: true })
+      try {
+        zipInfo = await parseWinZipAesZipInfoFromRemote(result.data.raw_url, ctx.req.headers, remoteFileSize, { stripAuth: true })
+      } catch (e) {
+        if (ctx.req.isExternalZipCandidate) {
+          ctx.body = result
+          return
+        }
+        throw e
+      }
       result.data.size = zipInfo.plainSize
     }
     const key = crypto.randomUUID()
     const virtualName = decodeURIComponent((ctx.req.encVirtualPath || path).split('/').pop() || '')
+    const previewName = (ctx.req.isExternalZip || ctx.req.isExternalZipCandidate) && zipInfo ? zipInfo.innerName : virtualName
     await levelDB.setExpire(
       key,
       {
         redirectUrl: result.data.raw_url,
         passwdInfo,
         fileSize: remoteFileSize,
-        virtualName,
+        virtualName: previewName,
         zipInfo: serializeWinZipAesZipInfo(zipInfo),
       },
       60 * 60 * 72
@@ -375,8 +398,8 @@ proxyRouter.all('/api/fs/get', bodyparserMw, async (ctx, next) => {
     result.data.raw_url = `${
       headers.origin || (headers['x-forwarded-proto'] || ctx.protocol) + '://' + ctx.req.selfHost
     }/redirect/${key}?decode=1&lastUrl=${encodeURIComponent(path)}`
-    if (virtualName) {
-      result.data.type = getAListFileTypeByName(virtualName)
+    if (previewName) {
+      result.data.type = getAListFileTypeByName(previewName)
     }
     if (isWinZipAesEncType(passwdInfo.encType) || result.data.provider === 'AliyundriveOpen') result.data.provider = 'Local'
   }

--- a/node-proxy/src/config.js
+++ b/node-proxy/src/config.js
@@ -36,6 +36,7 @@ const alistServerTemp = {
       encType: 'aesctr', // 算法类型，可选mix，rc4，winzip-aes-ctr，默认aesctr
       enable: true, // enable encrypt
       encName: false, // encrypt file name
+      zipAutoCache: false, // auto probe external WinZip AES ZIP in background
       encSuffix: '', //
       encPath: ['encrypt_folder/*', 'movie_encrypt/*'], // 路径支持正则表达式，常用的就是 尾巴带*，此目录的所文件都加密
     },
@@ -60,6 +61,7 @@ const webdavServerTemp = [
         describe: 'my video',
         enable: false,
         encName: false, // encrypt file name
+        zipAutoCache: false, // auto probe external WinZip AES ZIP in background
         encNameSuffix: '', //
         encPath: ['encrypt_folder/*', '/dav/189cloud/*'], // 子路径
       },

--- a/node-proxy/src/config.js
+++ b/node-proxy/src/config.js
@@ -36,6 +36,7 @@ const alistServerTemp = {
       encType: 'aesctr', // 算法类型，可选mix，rc4，winzip-aes-ctr，默认aesctr
       enable: true, // enable encrypt
       encName: false, // encrypt file name
+      zipInfoCache: true, // cache parsed WinZip AES ZIP fields for playback
       zipAutoCache: false, // auto probe external WinZip AES ZIP in background
       encSuffix: '', //
       encPath: ['encrypt_folder/*', 'movie_encrypt/*'], // 路径支持正则表达式，常用的就是 尾巴带*，此目录的所文件都加密
@@ -61,6 +62,7 @@ const webdavServerTemp = [
         describe: 'my video',
         enable: false,
         encName: false, // encrypt file name
+        zipInfoCache: true, // cache parsed WinZip AES ZIP fields for playback
         zipAutoCache: false, // auto probe external WinZip AES ZIP in background
         encNameSuffix: '', //
         encPath: ['encrypt_folder/*', '/dav/189cloud/*'], // 子路径

--- a/node-proxy/src/config.js
+++ b/node-proxy/src/config.js
@@ -33,7 +33,7 @@ const alistServerTemp = {
     {
       password: '123456',
       describe: 'my video', // 加密内容描述
-      encType: 'aesctr', // 算法类型，可选mix，rc4，默认aesctr
+      encType: 'aesctr', // 算法类型，可选mix，rc4，winzip-aes-ctr，默认aesctr
       enable: true, // enable encrypt
       encName: false, // encrypt file name
       encSuffix: '', //
@@ -56,7 +56,7 @@ const webdavServerTemp = [
     passwdList: [
       {
         password: '123456',
-        encType: 'aesctr', // 密码类型，mix：速度更快适合电视盒子之类，rc4: 更安全，速度比mix慢一点，几乎无感知。
+        encType: 'aesctr', // 密码类型，mix：速度更快适合电视盒子之类，rc4: 更安全，速度比mix慢一点，几乎无感知。winzip-aes-ctr: 标准WinZip AES压缩包。
         describe: 'my video',
         enable: false,
         encName: false, // encrypt file name

--- a/node-proxy/src/dao/fileDao.js
+++ b/node-proxy/src/dao/fileDao.js
@@ -9,11 +9,23 @@ const cacheTime = 60 * 24
 export async function initFileTable() {}
 
 // 缓存文件信息
-export async function cacheFileInfo(fileInfo) {
+export async function cacheFileInfo(fileInfo, expireSeconds = 1000 * 60 * cacheTime) {
   fileInfo.path = decodeURIComponent(fileInfo.path)
   const pathKey = fileInfoTable + fileInfo.path
+  const cachedFileInfo = await levelDB.getValue(pathKey)
+  if (
+    cachedFileInfo &&
+    cachedFileInfo.zipInfo &&
+    !fileInfo.zipInfo &&
+    Number(cachedFileInfo.size) === Number(fileInfo.size)
+  ) {
+    fileInfo.plainSize = cachedFileInfo.plainSize
+    fileInfo.zipInfo = cachedFileInfo.zipInfo
+    fileInfo.externalZip = cachedFileInfo.externalZip
+    fileInfo.zipVirtualName = cachedFileInfo.zipVirtualName
+  }
   fileInfo.table = fileInfoTable
-  await levelDB.setExpire(pathKey, fileInfo, 1000 * 60 * cacheTime)
+  await levelDB.setExpire(pathKey, fileInfo, expireSeconds)
 }
 
 // 获取文件信息，偶尔要清理一下缓存

--- a/node-proxy/src/encDavHandle.js
+++ b/node-proxy/src/encDavHandle.js
@@ -109,6 +109,10 @@ function rewriteWebdavContentLength(respBody, fileInfo, plainSize) {
   )
 }
 
+function isWebdavFileRequest(url, fileName) {
+  return !url.endsWith('/') && !!path.extname(decodeURIComponent(fileName || ''))
+}
+
 // 拦截全部
 const handle = async (ctx, next) => {
   const request = ctx.req
@@ -127,7 +131,7 @@ const handle = async (ctx, next) => {
       const sourceFileInfo = await getFileInfo(sourceUrl)
       logger.debug('@@@sourceFileInfo', sourceFileInfo, reqFileName, realName, url, sourceUrl)
       // it is file, convert file name
-      if (sourceFileInfo && !sourceFileInfo.is_dir) {
+      if ((sourceFileInfo && !sourceFileInfo.is_dir) || isWebdavFileRequest(url, reqFileName)) {
         request.url = path.dirname(request.url) + '/' + realName
         request.urlAddr = path.dirname(request.urlAddr) + '/' + realName
       }

--- a/node-proxy/src/encDavHandle.js
+++ b/node-proxy/src/encDavHandle.js
@@ -6,7 +6,11 @@ import { logger } from './common/logger'
 import path from 'path'
 import { httpClient } from './utils/httpClient'
 import { XMLParser } from 'fast-xml-parser'
-import WinZipAesZip, { isWinZipAesEncType } from './utils/winZipAesZip'
+import WinZipAesZip, {
+  isWinZipAesEncType,
+  parseWinZipAesZipInfoFromRemote,
+  serializeWinZipAesZipInfo,
+} from './utils/winZipAesZip'
 // import { escape } from 'querystring'
 
 async function sleep(time) {
@@ -20,15 +24,17 @@ async function sleep(time) {
 // bodyparser解析body
 const parser = new XMLParser({ removeNSPrefix: true })
 
+function getProp(fileInfo) {
+  if (fileInfo.propstat instanceof Array) return fileInfo.propstat[0].prop
+  return fileInfo.propstat.prop
+}
+
 function getFileNameForShow(fileInfo, passwdInfo) {
   let getcontentlength = -1
   const href = fileInfo.href
   const fileName = path.basename(href)
-  if (fileInfo.propstat instanceof Array) {
-    getcontentlength = fileInfo.propstat[0].prop.getcontentlength
-  } else if (fileInfo.propstat.prop) {
-    getcontentlength = fileInfo.propstat.prop.getcontentlength
-  }
+  const prop = getProp(fileInfo)
+  if (prop) getcontentlength = prop.getcontentlength
   // logger.debug('@@fileInfo_show', JSON.stringify(fileInfo))
   // is not dir
   if (getcontentlength !== undefined && getcontentlength > -1) {
@@ -43,11 +49,8 @@ function cacheWebdavFileInfo(fileInfo) {
   let getcontentlength = -1
   const href = fileInfo.href
   const fileName = path.basename(href)
-  if (fileInfo.propstat instanceof Array) {
-    getcontentlength = fileInfo.propstat[0].prop.getcontentlength
-  } else if (fileInfo.propstat.prop) {
-    getcontentlength = fileInfo.propstat.prop.getcontentlength
-  }
+  const prop = getProp(fileInfo)
+  if (prop) getcontentlength = prop.getcontentlength
   // logger.debug('@@@cacheWebdavFileInfo', href, fileName)
   // it is a file
   if (getcontentlength !== undefined && getcontentlength > -1) {
@@ -59,6 +62,51 @@ function cacheWebdavFileInfo(fileInfo) {
   const fileDetail = { path: href, name: fileName, is_dir: true, size: 0 }
   cacheFileInfo(fileDetail)
   return fileDetail
+}
+
+function xmlEscapeText(value) {
+  return String(value).replace(/&/g, '&amp;').replace(/</g, '&gt;')
+}
+
+function replaceOnce(text, from, to) {
+  const index = text.indexOf(from)
+  if (index < 0) return text
+  return text.slice(0, index) + to + text.slice(index + from.length)
+}
+
+async function prepareWinZipAesWebdavFileInfo(fileDetail, request) {
+  if (!fileDetail || fileDetail.is_dir || fileDetail.zipInfo) return fileDetail
+  const cachedFileInfo = await getFileInfo(fileDetail.path)
+  if (
+    cachedFileInfo &&
+    cachedFileInfo.zipInfo &&
+    isWinZipAesEncType(cachedFileInfo.zipInfo.encType) &&
+    Number(cachedFileInfo.size) === Number(fileDetail.size)
+  ) {
+    return {
+      ...fileDetail,
+      plainSize: cachedFileInfo.plainSize,
+      zipInfo: cachedFileInfo.zipInfo,
+    }
+  }
+  const zipInfo = await parseWinZipAesZipInfoFromRemote(request.urlAddr, request.headers, fileDetail.size)
+  const nextFileInfo = {
+    ...fileDetail,
+    plainSize: zipInfo.plainSize,
+    zipInfo: serializeWinZipAesZipInfo(zipInfo),
+  }
+  await cacheFileInfo(nextFileInfo)
+  return nextFileInfo
+}
+
+function rewriteWebdavContentLength(respBody, fileInfo, plainSize) {
+  const prop = getProp(fileInfo)
+  if (!prop || prop.getcontentlength === undefined || plainSize === undefined) return respBody
+  return replaceOnce(
+    respBody,
+    `<D:getcontentlength>${prop.getcontentlength}</D:getcontentlength>`,
+    `<D:getcontentlength>${plainSize}</D:getcontentlength>`
+  )
 }
 
 // 拦截全部
@@ -92,27 +140,39 @@ const handle = async (ctx, next) => {
       const respJson = respData.multistatus.response
       if (respJson instanceof Array) {
         // console.log('@@respJsonArray', respJson)
-        respJson.forEach((fileInfo) => {
+        for (const fileInfo of respJson) {
           // cache real file info，include forder name
-          cacheWebdavFileInfo(fileInfo)
+          let fileDetail = cacheWebdavFileInfo(fileInfo)
+          if (isWinZipAesEncType(passwdInfo.encType) && fileDetail && !fileDetail.is_dir) {
+            const oldUrlAddr = request.urlAddr
+            request.urlAddr = request.serverAddr + fileDetail.path
+            fileDetail = await prepareWinZipAesWebdavFileInfo(fileDetail, request)
+            request.urlAddr = oldUrlAddr
+            respBody = rewriteWebdavContentLength(respBody, fileInfo, fileDetail.plainSize)
+          }
           if (passwdInfo && passwdInfo.encName) {
             const { fileName, showName } = getFileNameForShow(fileInfo, passwdInfo)
             // logger.debug('@@getFileNameForShow1 list', passwdInfo.password, fileName, decodeURI(fileName), showName)
             if (fileName) {
-              const showXmlName = showName.replace(/&/g, '&amp;').replace(/</g, '&gt;')
+              const showXmlName = xmlEscapeText(showName)
               respBody = respBody.replace(`${fileName}</D:href>`, `${encodeURI(showXmlName)}</D:href>`)
               respBody = respBody.replace(`${decodeURI(fileName)}</D:displayname>`, `${decodeURI(showXmlName)}</D:displayname>`)
             }
           }
-        })
+        }
         // waiting cacheWebdavFileInfo a moment
         await sleep(50)
       } else if (passwdInfo && passwdInfo.encName) {
         const fileInfo = respJson
+        let fileDetail = cacheWebdavFileInfo(fileInfo)
+        if (isWinZipAesEncType(passwdInfo.encType) && fileDetail && !fileDetail.is_dir) {
+          fileDetail = await prepareWinZipAesWebdavFileInfo(fileDetail, request)
+          respBody = rewriteWebdavContentLength(respBody, fileInfo, fileDetail.plainSize)
+        }
         const { fileName, showName } = getFileNameForShow(fileInfo, passwdInfo)
         // logger.debug('@@getFileNameForShow2 file', fileName, showName, url, respJson.propstat)
         if (fileName) {
-          const showXmlName = showName.replace(/&/g, '&amp;').replace(/</g, '&gt;')
+          const showXmlName = xmlEscapeText(showName)
           respBody = respBody.replace(`${fileName}</D:href>`, `${encodeURI(showXmlName)}</D:href>`)
           respBody = respBody.replace(`${decodeURI(fileName)}</D:displayname>`, `${decodeURI(showXmlName)}</D:displayname>`)
         }
@@ -173,8 +233,15 @@ const handle = async (ctx, next) => {
     }
 
     // console.log('@@convert file name', fileName, realName)
+    if (isWinZipAesEncType(passwdInfo.encType)) {
+      request.zipVirtualName = decodeURIComponent(fileName)
+    }
     request.url = path.dirname(request.url) + '/' + realName
     request.urlAddr = path.dirname(request.urlAddr) + '/' + realName
+    if (request.method.toLocaleUpperCase() !== 'PUT') {
+      await next()
+      return
+    }
     // cache file before upload in next(), rclone cmd 'copy' will PROPFIND this file when the file upload success right now
     const contentLength = request.headers['content-length'] || request.headers['x-expected-entity-length'] || 0
     const fileSize = isWinZipAesEncType(passwdInfo.encType)

--- a/node-proxy/src/encDavHandle.js
+++ b/node-proxy/src/encDavHandle.js
@@ -6,6 +6,7 @@ import { logger } from './common/logger'
 import path from 'path'
 import { httpClient } from './utils/httpClient'
 import { XMLParser } from 'fast-xml-parser'
+import WinZipAesZip, { isWinZipAesEncType } from './utils/winZipAesZip'
 // import { escape } from 'querystring'
 
 async function sleep(time) {
@@ -176,7 +177,10 @@ const handle = async (ctx, next) => {
     request.urlAddr = path.dirname(request.urlAddr) + '/' + realName
     // cache file before upload in next(), rclone cmd 'copy' will PROPFIND this file when the file upload success right now
     const contentLength = request.headers['content-length'] || request.headers['x-expected-entity-length'] || 0
-    const fileDetail = { path: url, name: fileName, is_dir: false, size: contentLength }
+    const fileSize = isWinZipAesEncType(passwdInfo.encType)
+      ? WinZipAesZip.packageSize(contentLength * 1, { originalName: fileName })
+      : contentLength
+    const fileDetail = { path: path.dirname(url) + '/' + realName, name: realName, is_dir: false, size: fileSize }
     logger.info('@@@put url', url)
     // 在页面上传文件，rclone会重复上传，所以要进行缓存文件信息，也不能在next() 因为rclone copy命令会出异常
     await cacheFileInfo(fileDetail)

--- a/node-proxy/src/encDavHandle.js
+++ b/node-proxy/src/encDavHandle.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { pathFindPasswd, convertRealName, convertShowName } from './utils/commonUtil'
+import { pathFindPasswd, convertRealName, convertShowName, getOrigName, isEncryptedZipName, isOrigName, isRawZipName } from './utils/commonUtil'
 import { cacheFileInfo, getFileInfo } from './dao/fileDao'
 import { logger } from './common/logger'
 import path from 'path'
@@ -38,7 +38,11 @@ function getFileNameForShow(fileInfo, passwdInfo) {
   // logger.debug('@@fileInfo_show', JSON.stringify(fileInfo))
   // is not dir
   if (getcontentlength !== undefined && getcontentlength > -1) {
-    const showName = convertShowName(passwdInfo.password, passwdInfo.encType, href)
+    const showName = isWinZipAesEncType(passwdInfo.encType)
+      ? isEncryptedZipName(passwdInfo.password, passwdInfo.encType, fileName)
+        ? convertShowName(passwdInfo.password, passwdInfo.encType, href)
+        : fileName
+      : convertShowName(passwdInfo.password, passwdInfo.encType, href)
     return { fileName, showName }
   }
   // cache this folder info
@@ -74,29 +78,40 @@ function replaceOnce(text, from, to) {
   return text.slice(0, index) + to + text.slice(index + from.length)
 }
 
-async function prepareWinZipAesWebdavFileInfo(fileDetail, request) {
+async function prepareWinZipAesWebdavFileInfo(fileDetail, request, passwdInfo) {
   if (!fileDetail || fileDetail.is_dir || fileDetail.zipInfo) return fileDetail
+  if (!String(fileDetail.name || '').toLowerCase().endsWith('.zip')) return fileDetail
+  const isManagedZipName = isEncryptedZipName(passwdInfo.password, passwdInfo.encType, fileDetail.name)
   const cachedFileInfo = await getFileInfo(fileDetail.path)
   if (
     cachedFileInfo &&
     cachedFileInfo.zipInfo &&
     isWinZipAesEncType(cachedFileInfo.zipInfo.encType) &&
-    Number(cachedFileInfo.size) === Number(fileDetail.size)
+    Number(cachedFileInfo.size) === Number(fileDetail.size) &&
+    !!cachedFileInfo.externalZip === !isManagedZipName
   ) {
     return {
       ...fileDetail,
       plainSize: cachedFileInfo.plainSize,
       zipInfo: cachedFileInfo.zipInfo,
+      externalZip: cachedFileInfo.externalZip,
+      zipVirtualName: cachedFileInfo.zipVirtualName,
     }
   }
-  const zipInfo = await parseWinZipAesZipInfoFromRemote(request.urlAddr, request.headers, fileDetail.size)
-  const nextFileInfo = {
-    ...fileDetail,
-    plainSize: zipInfo.plainSize,
-    zipInfo: serializeWinZipAesZipInfo(zipInfo),
+  try {
+    const zipInfo = await parseWinZipAesZipInfoFromRemote(request.urlAddr, request.headers, fileDetail.size)
+    const nextFileInfo = {
+      ...fileDetail,
+      plainSize: zipInfo.plainSize,
+      zipInfo: serializeWinZipAesZipInfo(zipInfo),
+      externalZip: !isManagedZipName,
+      zipVirtualName: isManagedZipName ? undefined : fileDetail.name,
+    }
+    await cacheFileInfo(nextFileInfo)
+    return nextFileInfo
+  } catch (e) {
+    return fileDetail
   }
-  await cacheFileInfo(nextFileInfo)
-  return nextFileInfo
 }
 
 function rewriteWebdavContentLength(respBody, fileInfo, plainSize) {
@@ -113,6 +128,21 @@ function isWebdavFileRequest(url, fileName) {
   return !url.endsWith('/') && !!path.extname(decodeURIComponent(fileName || ''))
 }
 
+function getRequestRealName(passwdInfo, url, fileInfo) {
+  const fileName = path.basename(url)
+  if (fileInfo && fileInfo.externalZip) return fileInfo.name || fileName
+  if (isRawZipName(passwdInfo.password, passwdInfo.encType, fileName)) return fileName
+  if (isOrigName(fileName)) return getOrigName(fileName)
+  return convertRealName(passwdInfo.password, passwdInfo.encType, url)
+}
+
+function getExternalZipRenameTarget(fileInfo, destinationName) {
+  if (!fileInfo || !fileInfo.externalZip) return destinationName
+  if (path.extname(destinationName).toLowerCase() !== '.zip') return destinationName
+  const innerExt = path.extname((fileInfo.zipInfo && fileInfo.zipInfo.innerName) || '')
+  return innerExt ? path.basename(destinationName, '.zip') + innerExt : destinationName
+}
+
 // 拦截全部
 const handle = async (ctx, next) => {
   const request = ctx.req
@@ -125,13 +155,18 @@ const handle = async (ctx, next) => {
       // check dir, convert url
       const reqFileName = path.basename(url)
       // cache source file info, realName has execute encodeUrl()，this '(' '+' can't encodeUrl.
-      const realName = convertRealName(passwdInfo.password, passwdInfo.encType, url)
+      const isManagedZipName = isEncryptedZipName(passwdInfo.password, passwdInfo.encType, reqFileName)
+      const realName =
+        isManagedZipName || !isRawZipName(passwdInfo.password, passwdInfo.encType, reqFileName)
+          ? convertRealName(passwdInfo.password, passwdInfo.encType, url)
+          : reqFileName
       // when the name contain the + , ! ,
       const sourceUrl = path.dirname(url) + '/' + realName
       const sourceFileInfo = await getFileInfo(sourceUrl)
       logger.debug('@@@sourceFileInfo', sourceFileInfo, reqFileName, realName, url, sourceUrl)
       // it is file, convert file name
       if ((sourceFileInfo && !sourceFileInfo.is_dir) || isWebdavFileRequest(url, reqFileName)) {
+        request.isManagedZipName = isManagedZipName
         request.url = path.dirname(request.url) + '/' + realName
         request.urlAddr = path.dirname(request.urlAddr) + '/' + realName
       }
@@ -150,7 +185,7 @@ const handle = async (ctx, next) => {
           if (isWinZipAesEncType(passwdInfo.encType) && fileDetail && !fileDetail.is_dir) {
             const oldUrlAddr = request.urlAddr
             request.urlAddr = request.serverAddr + fileDetail.path
-            fileDetail = await prepareWinZipAesWebdavFileInfo(fileDetail, request)
+            fileDetail = await prepareWinZipAesWebdavFileInfo(fileDetail, request, passwdInfo)
             request.urlAddr = oldUrlAddr
             respBody = rewriteWebdavContentLength(respBody, fileInfo, fileDetail.plainSize)
           }
@@ -170,7 +205,7 @@ const handle = async (ctx, next) => {
         const fileInfo = respJson
         let fileDetail = cacheWebdavFileInfo(fileInfo)
         if (isWinZipAesEncType(passwdInfo.encType) && fileDetail && !fileDetail.is_dir) {
-          fileDetail = await prepareWinZipAesWebdavFileInfo(fileDetail, request)
+          fileDetail = await prepareWinZipAesWebdavFileInfo(fileDetail, request, passwdInfo)
           respBody = rewriteWebdavContentLength(respBody, fileInfo, fileDetail.plainSize)
         }
         const { fileName, showName } = getFileNameForShow(fileInfo, passwdInfo)
@@ -200,8 +235,11 @@ const handle = async (ctx, next) => {
   // copy or move file
   if ('COPY,MOVE'.includes(request.method.toLocaleUpperCase()) && passwdInfo && passwdInfo.encName) {
     const url = request.url
-    const realName = convertRealName(passwdInfo.password, passwdInfo.encType, url)
-    request.headers.destination = path.dirname(request.headers.destination) + '/' + encodeURI(realName)
+    const fileInfo = await getFileInfo(url)
+    const realName = getRequestRealName(passwdInfo, url, fileInfo)
+    const destinationName = path.basename(decodeURIComponent(request.headers.destination || ''))
+    const destinationRealName = convertRealName(passwdInfo.password, passwdInfo.encType, getExternalZipRenameTarget(fileInfo, destinationName))
+    request.headers.destination = path.dirname(request.headers.destination) + '/' + encodeURI(destinationRealName)
     request.url = path.dirname(request.url) + '/' + encodeURI(realName)
     request.urlAddr = path.dirname(request.urlAddr) + '/' + encodeURI(realName)
   }
@@ -211,7 +249,8 @@ const handle = async (ctx, next) => {
     const url = request.url
     // check dir, convert url
     const fileName = path.basename(url)
-    const realName = convertRealName(passwdInfo.password, passwdInfo.encType, url)
+    const cachedFileInfo = await getFileInfo(url)
+    const realName = getRequestRealName(passwdInfo, url, cachedFileInfo)
     // maybe from aliyundrive, check this req url while get file list from enc folder
     if (url.endsWith('/') && 'GET,DELETE'.includes(request.method.toLocaleUpperCase())) {
       let respBody = await httpClient(ctx.req, ctx.res)
@@ -238,7 +277,15 @@ const handle = async (ctx, next) => {
 
     // console.log('@@convert file name', fileName, realName)
     if (isWinZipAesEncType(passwdInfo.encType)) {
-      request.zipVirtualName = decodeURIComponent(fileName)
+      request.isExternalZip = cachedFileInfo && cachedFileInfo.externalZip
+      request.isExternalZipCandidate = !request.isExternalZip && isRawZipName(passwdInfo.password, passwdInfo.encType, fileName)
+      request.originalName = decodeURIComponent(fileName)
+      request.zipVirtualName =
+        request.isExternalZip && cachedFileInfo.zipInfo
+          ? cachedFileInfo.zipInfo.innerName
+          : request.isExternalZipCandidate
+            ? undefined
+            : decodeURIComponent(fileName)
     }
     request.url = path.dirname(request.url) + '/' + realName
     request.urlAddr = path.dirname(request.urlAddr) + '/' + realName

--- a/node-proxy/src/encDavHandle.js
+++ b/node-proxy/src/encDavHandle.js
@@ -11,6 +11,7 @@ import WinZipAesZip, {
   parseWinZipAesZipInfoFromRemote,
   serializeWinZipAesZipInfo,
 } from './utils/winZipAesZip'
+import { enqueueExternalWinZipAesZipProbe } from './utils/winZipAesZipCache'
 // import { escape } from 'querystring'
 
 async function sleep(time) {
@@ -82,6 +83,16 @@ async function prepareWinZipAesWebdavFileInfo(fileDetail, request, passwdInfo) {
   if (!fileDetail || fileDetail.is_dir || fileDetail.zipInfo) return fileDetail
   if (!String(fileDetail.name || '').toLowerCase().endsWith('.zip')) return fileDetail
   const isManagedZipName = isEncryptedZipName(passwdInfo.password, passwdInfo.encType, fileDetail.name)
+  if (!isManagedZipName) {
+    if (passwdInfo.zipAutoCache) {
+      enqueueExternalWinZipAesZipProbe({
+        fileInfo: fileDetail,
+        urlAddr: request.urlAddr,
+        headers: request.headers,
+      })
+    }
+    return fileDetail
+  }
   const cachedFileInfo = await getFileInfo(fileDetail.path)
   if (
     cachedFileInfo &&

--- a/node-proxy/src/encNameRouter.js
+++ b/node-proxy/src/encNameRouter.js
@@ -2,13 +2,22 @@
 
 import Router from 'koa-router'
 import bodyparser from 'koa-bodyparser'
-import { encodeName, pathFindPasswd, convertShowName, convertRealName } from './utils/commonUtil'
+import {
+  encodeName,
+  pathFindPasswd,
+  convertShowName,
+  convertRealName,
+  getAListFileTypeByName,
+  getOrigName,
+  isEncryptedZipName,
+  isOrigName,
+} from './utils/commonUtil'
 import path from 'path'
 import { httpClient, httpProxy } from './utils/httpClient'
 import FlowEnc from './utils/flowEnc'
 import { logger } from './common/logger'
-import { getFileInfo } from './dao/fileDao'
-import WinZipAesZip, { isWinZipAesEncType } from './utils/winZipAesZip'
+import { cacheFileInfo, getFileInfo } from './dao/fileDao'
+import WinZipAesZip, { isWinZipAesEncType, parseWinZipAesZipInfoFromRemote, serializeWinZipAesZipInfo } from './utils/winZipAesZip'
 
 // bodyparser解析body
 const bodyparserMw = bodyparser({ enableTypes: ['json', 'form', 'text'] })
@@ -24,6 +33,101 @@ function getEncryptedFileName(passwdInfo, fileName) {
   const ext = passwdInfo.encSuffix || path.extname(baseName)
   const encName = encodeName(passwdInfo.password, passwdInfo.encType, baseName)
   return encName + ext
+}
+
+function getZipPreviewName(fileInfo) {
+  return fileInfo.showName || fileInfo.name
+}
+
+async function getCachedFileInfoByPath(filePath) {
+  return (await getFileInfo(encodeURIComponent(filePath))) || (await getFileInfo(filePath))
+}
+
+function isRawZipName(passwdInfo, fileName) {
+  return (
+    isWinZipAesEncType(passwdInfo.encType) &&
+    String(fileName || '').toLowerCase().endsWith('.zip') &&
+    !isEncryptedZipName(passwdInfo.password, passwdInfo.encType, fileName)
+  )
+}
+
+function getRequestRealName(passwdInfo, fileName, fileInfo) {
+  if (fileInfo && fileInfo.externalZip) {
+    return fileInfo.name || fileName
+  }
+  if (isRawZipName(passwdInfo, fileName)) {
+    return fileName
+  }
+  return isOrigName(fileName) ? getOrigName(fileName) : convertRealName(passwdInfo.password, passwdInfo.encType, fileName)
+}
+
+function getShowName(passwdInfo, rawName, fileInfo) {
+  if (fileInfo && fileInfo.externalZip) {
+    return rawName
+  }
+  if (isRawZipName(passwdInfo, rawName)) {
+    return rawName
+  }
+  return convertShowName(passwdInfo.password, passwdInfo.encType, rawName)
+}
+
+function getExternalZipRenameTarget(fileInfo, name) {
+  if (!fileInfo || !fileInfo.externalZip) return name
+  if (path.extname(name).toLowerCase() !== '.zip') return name
+  const zipInfo = fileInfo.zipInfo || {}
+  const innerExt = path.extname(zipInfo.innerName || '')
+  return innerExt ? path.basename(name, '.zip') + innerExt : name
+}
+
+function joinUrlPath(dir, name) {
+  return `${String(dir || '').replace(/\/$/, '')}/${name}`
+}
+
+async function prepareWinZipAesListFileInfo(fileInfo, request, passwdInfo) {
+  if (!isWinZipAesEncType(passwdInfo.encType) || fileInfo.is_dir || !String(fileInfo.name || '').toLowerCase().endsWith('.zip')) {
+    return fileInfo
+  }
+  const isManaged = isEncryptedZipName(passwdInfo.password, passwdInfo.encType, fileInfo.name)
+  if (isManaged) {
+    fileInfo.name = convertShowName(passwdInfo.password, passwdInfo.encType, fileInfo.name)
+    fileInfo.type = getAListFileTypeByName(fileInfo.name)
+    return fileInfo
+  }
+  try {
+    const cachedFileInfo = await getFileInfo(fileInfo.path)
+    let zipInfo = cachedFileInfo && cachedFileInfo.zipInfo
+    let plainSize = cachedFileInfo && cachedFileInfo.plainSize
+    if (!zipInfo || !cachedFileInfo || Number(cachedFileInfo.size) !== Number(fileInfo.size)) {
+      const oldUrlAddr = request.urlAddr
+      let parsedZipInfo
+      try {
+        request.urlAddr = request.serverAddr + fileInfo.path
+        parsedZipInfo = await parseWinZipAesZipInfoFromRemote(request.urlAddr, request.headers, fileInfo.size)
+      } finally {
+        request.urlAddr = oldUrlAddr
+      }
+      zipInfo = serializeWinZipAesZipInfo(parsedZipInfo)
+      plainSize = parsedZipInfo.plainSize
+      await cacheFileInfo({
+        ...fileInfo,
+        size: fileInfo.size,
+        plainSize,
+        zipInfo,
+        externalZip: true,
+        zipVirtualName: fileInfo.name,
+      })
+    }
+    fileInfo.plainSize = plainSize
+    fileInfo.zipInfo = zipInfo
+    fileInfo.externalZip = true
+    fileInfo.type = getAListFileTypeByName(zipInfo.innerName)
+    if (plainSize !== undefined) {
+      fileInfo.size = plainSize
+    }
+  } catch (e) {
+    // Keep ordinary ZIP files untouched.
+  }
+  return fileInfo
 }
 
 // 拦截全部
@@ -46,7 +150,10 @@ encNameRouter.all('/api/fs/list', async (ctx, next) => {
       //  Check path if the file name needs to be encrypted
       const { passwdInfo } = pathFindPasswd(passwdList, decodeURI(fileInfo.path))
       if (passwdInfo && passwdInfo.encName) {
-        fileInfo.name = convertShowName(passwdInfo.password, passwdInfo.encType, fileInfo.name)
+        await prepareWinZipAesListFileInfo(fileInfo, ctx.req, passwdInfo)
+        if (!isWinZipAesEncType(passwdInfo.encType)) {
+          fileInfo.name = convertShowName(passwdInfo.password, passwdInfo.encType, fileInfo.name)
+        }
       }
     }
 
@@ -65,7 +172,7 @@ encNameRouter.all('/api/fs/list', async (ctx, next) => {
       if (fileInfo.is_dir) {
         return
       }
-      const coverName = coverNameMap[fileInfo.name.split('.')[0]]
+      const coverName = coverNameMap[getZipPreviewName(fileInfo).split('.')[0]]
       if (fileInfo.type === 2 && coverName) {
         omitNames.push(coverName)
         fileInfo.thumb = `/d${path}/${coverName}`
@@ -141,6 +248,11 @@ const copyOrMoveFile = async (ctx, next) => {
         fileNames.push(origName)
         break
       }
+      const cachedFileInfo = await getCachedFileInfoByPath(joinUrlPath(srcDir, name))
+      if ((cachedFileInfo && cachedFileInfo.externalZip) || isRawZipName(passwdInfo, name)) {
+        fileNames.push(name)
+        continue
+      }
       const newFileName = getEncryptedFileName(passwdInfo, name)
       fileNames.push(newFileName)
     }
@@ -163,19 +275,27 @@ encNameRouter.all('/api/fs/get', bodyparserMw, async (ctx, next) => {
   const { path: filePath } = ctx.request.body
   const { webdavConfig } = ctx.req
   const { passwdInfo } = pathFindPasswd(webdavConfig.passwdList, filePath)
+  let fileInfo = null
   if (passwdInfo && passwdInfo.encName) {
     ctx.req.encVirtualPath = filePath
     // reset content-length length
     delete ctx.req.headers['content-length']
     // check fileName is not enc
     const fileName = path.basename(filePath)
-    const fileInfo = await getFileInfo(encodeURIComponent(filePath))
+    fileInfo = await getCachedFileInfoByPath(filePath)
     if (fileInfo && fileInfo.is_dir) {
       await next()
       return
     }
+    if (isWinZipAesEncType(passwdInfo.encType)) {
+      ctx.req.isExternalZip = !!(fileInfo && fileInfo.externalZip)
+      ctx.req.isExternalZipCandidate = !ctx.req.isExternalZip && isRawZipName(passwdInfo, fileName)
+      if (ctx.req.isExternalZip && fileInfo.zipInfo) {
+        ctx.req.zipVirtualName = fileInfo.zipInfo.innerName
+      }
+    }
     //  Check if it is a directory
-    const realName = convertRealName(passwdInfo.password, passwdInfo.encType, fileName)
+    const realName = getRequestRealName(passwdInfo, fileName, fileInfo)
     const fpath = path.dirname(filePath) + '/' + realName
     console.log('@@@getFilePath', fpath)
     ctx.request.body.path = fpath
@@ -183,8 +303,13 @@ encNameRouter.all('/api/fs/get', bodyparserMw, async (ctx, next) => {
   await next()
   if (passwdInfo && passwdInfo.encName) {
     // return showName
-    const showName = convertShowName(passwdInfo.password, passwdInfo.encType, ctx.body.data.name)
+    const showName = getShowName(passwdInfo, ctx.body.data.name, fileInfo)
     ctx.body.data.name = showName
+    if (fileInfo && fileInfo.externalZip && fileInfo.zipInfo) {
+      ctx.body.data.type = getAListFileTypeByName(fileInfo.zipInfo.innerName)
+    } else if (!ctx.req.isExternalZipCandidate) {
+      ctx.body.data.type = getAListFileTypeByName(showName)
+    }
   }
 })
 
@@ -197,20 +322,22 @@ encNameRouter.all('/api/fs/rename', bodyparserMw, async (ctx, next) => {
   // reset content-length length
   delete ctx.req.headers['content-length']
 
-  let fileInfo = await getFileInfo(encodeURIComponent(filePath))
+  let fileInfo = await getCachedFileInfoByPath(filePath)
   if (fileInfo == null && passwdInfo && passwdInfo.encName) {
     // mabay a file
     const realName = convertRealName(passwdInfo.password, passwdInfo.encType, filePath)
     const realFilePath = path.dirname(filePath) + '/' + realName
-    fileInfo = await getFileInfo(encodeURIComponent(realFilePath))
+    fileInfo = await getCachedFileInfoByPath(realFilePath)
   }
   if (passwdInfo && passwdInfo.encName && fileInfo && !fileInfo.is_dir) {
     // reset content-length length
     // you can custom Suffix
-    const realName = convertRealName(passwdInfo.password, passwdInfo.encType, filePath)
+    const realName = fileInfo.externalZip
+      ? fileInfo.name
+      : convertRealName(passwdInfo.password, passwdInfo.encType, filePath)
     const fpath = path.dirname(filePath) + '/' + realName
     reqBody.path = fpath
-    reqBody.name = getEncryptedFileName(passwdInfo, name)
+    reqBody.name = getEncryptedFileName(passwdInfo, getExternalZipRenameTarget(fileInfo, name))
   }
   ctx.req.reqBody = reqBody
   console.log('@@@rename', reqBody)
@@ -239,7 +366,8 @@ const handleDownload = async (ctx, next) => {
     delete ctx.req.headers['content-length']
     // Check whether the file name refers to an encrypted file or a directory
     const fileName = path.basename(filePath)
-    const realName = convertRealName(passwdInfo.password, passwdInfo.encType, fileName)
+    const fileInfo = await getCachedFileInfoByPath(filePath)
+    const realName = getRequestRealName(passwdInfo, fileName, fileInfo)
     // Replace the real-name before downloading
     ctx.req.url = ctx.req.url.replace(regexPath, `/${realName}$2`)
     ctx.req.urlAddr = ctx.req.urlAddr.replace(regexPath, `/${realName}$2`)

--- a/node-proxy/src/encNameRouter.js
+++ b/node-proxy/src/encNameRouter.js
@@ -17,7 +17,8 @@ import { httpClient, httpProxy } from './utils/httpClient'
 import FlowEnc from './utils/flowEnc'
 import { logger } from './common/logger'
 import { cacheFileInfo, getFileInfo } from './dao/fileDao'
-import WinZipAesZip, { isWinZipAesEncType, parseWinZipAesZipInfoFromRemote, serializeWinZipAesZipInfo } from './utils/winZipAesZip'
+import WinZipAesZip, { isWinZipAesEncType } from './utils/winZipAesZip'
+import { enqueueExternalWinZipAesZipProbe } from './utils/winZipAesZipCache'
 
 // bodyparser解析body
 const bodyparserMw = bodyparser({ enableTypes: ['json', 'form', 'text'] })
@@ -83,7 +84,7 @@ function joinUrlPath(dir, name) {
   return `${String(dir || '').replace(/\/$/, '')}/${name}`
 }
 
-async function prepareWinZipAesListFileInfo(fileInfo, request, passwdInfo) {
+function prepareWinZipAesListFileInfo(fileInfo, request, passwdInfo) {
   if (!isWinZipAesEncType(passwdInfo.encType) || fileInfo.is_dir || !String(fileInfo.name || '').toLowerCase().endsWith('.zip')) {
     return fileInfo
   }
@@ -93,39 +94,12 @@ async function prepareWinZipAesListFileInfo(fileInfo, request, passwdInfo) {
     fileInfo.type = getAListFileTypeByName(fileInfo.name)
     return fileInfo
   }
-  try {
-    const cachedFileInfo = await getFileInfo(fileInfo.path)
-    let zipInfo = cachedFileInfo && cachedFileInfo.zipInfo
-    let plainSize = cachedFileInfo && cachedFileInfo.plainSize
-    if (!zipInfo || !cachedFileInfo || Number(cachedFileInfo.size) !== Number(fileInfo.size)) {
-      const oldUrlAddr = request.urlAddr
-      let parsedZipInfo
-      try {
-        request.urlAddr = request.serverAddr + fileInfo.path
-        parsedZipInfo = await parseWinZipAesZipInfoFromRemote(request.urlAddr, request.headers, fileInfo.size)
-      } finally {
-        request.urlAddr = oldUrlAddr
-      }
-      zipInfo = serializeWinZipAesZipInfo(parsedZipInfo)
-      plainSize = parsedZipInfo.plainSize
-      await cacheFileInfo({
-        ...fileInfo,
-        size: fileInfo.size,
-        plainSize,
-        zipInfo,
-        externalZip: true,
-        zipVirtualName: fileInfo.name,
-      })
-    }
-    fileInfo.plainSize = plainSize
-    fileInfo.zipInfo = zipInfo
-    fileInfo.externalZip = true
-    fileInfo.type = getAListFileTypeByName(zipInfo.innerName)
-    if (plainSize !== undefined) {
-      fileInfo.size = plainSize
-    }
-  } catch (e) {
-    // Keep ordinary ZIP files untouched.
+  if (passwdInfo.zipAutoCache) {
+    enqueueExternalWinZipAesZipProbe({
+      fileInfo,
+      urlAddr: request.serverAddr + fileInfo.path,
+      headers: request.headers,
+    })
   }
   return fileInfo
 }
@@ -150,7 +124,7 @@ encNameRouter.all('/api/fs/list', async (ctx, next) => {
       //  Check path if the file name needs to be encrypted
       const { passwdInfo } = pathFindPasswd(passwdList, decodeURI(fileInfo.path))
       if (passwdInfo && passwdInfo.encName) {
-        await prepareWinZipAesListFileInfo(fileInfo, ctx.req, passwdInfo)
+        prepareWinZipAesListFileInfo(fileInfo, ctx.req, passwdInfo)
         if (!isWinZipAesEncType(passwdInfo.encType)) {
           fileInfo.name = convertShowName(passwdInfo.password, passwdInfo.encType, fileInfo.name)
         }
@@ -295,6 +269,7 @@ encNameRouter.all('/api/fs/get', bodyparserMw, async (ctx, next) => {
       ctx.req.isExternalZipCandidate = !ctx.req.isExternalZip && isRawZipName(passwdInfo, fileName)
       if (ctx.req.isExternalZip && fileInfo.zipInfo) {
         ctx.req.zipVirtualName = fileInfo.zipInfo.innerName
+        ctx.req.cachedExternalZipInfo = fileInfo.zipInfo
       }
     }
     //  Check if it is a directory

--- a/node-proxy/src/encNameRouter.js
+++ b/node-proxy/src/encNameRouter.js
@@ -220,6 +220,9 @@ encNameRouter.all('/api/fs/remove', bodyparserMw, async (ctx, next) => {
   const fileNames = Object.assign([], names)
   if (passwdInfo && passwdInfo.encName) {
     for (const name of names) {
+      if (isRawZipName(passwdInfo, name)) {
+        continue
+      }
       // is not enc name
       const realName = convertRealName(passwdInfo.password, passwdInfo.encType, name)
       fileNames.push(realName)

--- a/node-proxy/src/encNameRouter.js
+++ b/node-proxy/src/encNameRouter.js
@@ -8,12 +8,23 @@ import { httpClient, httpProxy } from './utils/httpClient'
 import FlowEnc from './utils/flowEnc'
 import { logger } from './common/logger'
 import { getFileInfo } from './dao/fileDao'
+import WinZipAesZip, { isWinZipAesEncType } from './utils/winZipAesZip'
 
 // bodyparser解析body
 const bodyparserMw = bodyparser({ enableTypes: ['json', 'form', 'text'] })
 
 const encNameRouter = new Router()
 const origPrefix = 'orig_'
+
+function getEncryptedFileName(passwdInfo, fileName) {
+  const baseName = path.basename(fileName)
+  if (isWinZipAesEncType(passwdInfo.encType)) {
+    return convertRealName(passwdInfo.password, passwdInfo.encType, baseName)
+  }
+  const ext = passwdInfo.encSuffix || path.extname(baseName)
+  const encName = encodeName(passwdInfo.password, passwdInfo.encType, baseName)
+  return encName + ext
+}
 
 // 拦截全部
 encNameRouter.all('/api/fs/list', async (ctx, next) => {
@@ -78,13 +89,16 @@ encNameRouter.put('/api/fs/put', async (ctx, next) => {
     const fileName = path.basename(uploadPath)
     // you can custom Suffix
     if (passwdInfo.encName) {
-      const ext = passwdInfo.encSuffix || path.extname(fileName)
-      const encName = encodeName(passwdInfo.password, passwdInfo.encType, fileName)
-      const filePath = path.dirname(uploadPath) + '/' + encName + ext
+      const realName = getEncryptedFileName(passwdInfo, fileName)
+      const filePath = path.dirname(uploadPath) + '/' + realName
       console.log('@@@encfileName', fileName, uploadPath, filePath)
       headers['file-path'] = encodeURIComponent(filePath)
     }
-    const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, request.fileSize)
+    if (isWinZipAesEncType(passwdInfo.encType)) {
+      const packageSize = WinZipAesZip.packageSize(request.fileSize, { originalName: fileName })
+      headers['content-length'] = String(packageSize)
+    }
+    const flowEnc = new FlowEnc(passwdInfo.password, passwdInfo.encType, request.fileSize, { originalName: fileName })
     return await httpProxy(ctx.req, ctx.res, flowEnc.encryptTransform())
   }
   return await httpProxy(ctx.req, ctx.res)
@@ -127,11 +141,7 @@ const copyOrMoveFile = async (ctx, next) => {
         fileNames.push(origName)
         break
       }
-      const fileName = path.basename(name)
-      // you can custom Suffix
-      const ext = passwdInfo.encSuffix || path.extname(fileName)
-      const encName = encodeName(passwdInfo.password, passwdInfo.encType, fileName)
-      const newFileName = encName + ext
+      const newFileName = getEncryptedFileName(passwdInfo, name)
       fileNames.push(newFileName)
     }
   } else {
@@ -154,6 +164,7 @@ encNameRouter.all('/api/fs/get', bodyparserMw, async (ctx, next) => {
   const { webdavConfig } = ctx.req
   const { passwdInfo } = pathFindPasswd(webdavConfig.passwdList, filePath)
   if (passwdInfo && passwdInfo.encName) {
+    ctx.req.encVirtualPath = filePath
     // reset content-length length
     delete ctx.req.headers['content-length']
     // check fileName is not enc
@@ -196,12 +207,10 @@ encNameRouter.all('/api/fs/rename', bodyparserMw, async (ctx, next) => {
   if (passwdInfo && passwdInfo.encName && fileInfo && !fileInfo.is_dir) {
     // reset content-length length
     // you can custom Suffix
-    const ext = passwdInfo.encSuffix || path.extname(name)
     const realName = convertRealName(passwdInfo.password, passwdInfo.encType, filePath)
     const fpath = path.dirname(filePath) + '/' + realName
-    const newName = encodeName(passwdInfo.password, passwdInfo.encType, name)
     reqBody.path = fpath
-    reqBody.name = newName + ext
+    reqBody.name = getEncryptedFileName(passwdInfo, name)
   }
   ctx.req.reqBody = reqBody
   console.log('@@@rename', reqBody)

--- a/node-proxy/src/utils/commonUtil.ts
+++ b/node-proxy/src/utils/commonUtil.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 import MixBase64 from './mixBase64'
 import Crcn from './crc6-8'
+import { isWinZipAesEncType } from './winZipAesZip'
 
 const crc6 = new Crcn(6)
 const origPrefix = 'orig_'
@@ -18,18 +19,22 @@ export function convertRealName(password: string, encType: string, pathText: str
   const ext = path.extname(fileName)
   const encName = encodeName(password, encType, decodeURIComponent(fileName))
   console.log('@@decodeURI(fileName)', decodeURIComponent(fileName))
-  return encName + ext
+  return encName + ext + (isWinZipAesEncType(encType) ? '.zip' : '')
 }
 
 // if file name has encrypt, return show name
 export function convertShowName(password: string, encType: string, pathText: string) {
-  const fileName = path.basename(decodeURIComponent(pathText))
+  const rawFileName = path.basename(decodeURIComponent(pathText))
+  let fileName = rawFileName
+  if (isWinZipAesEncType(encType) && fileName.toLowerCase().endsWith('.zip')) {
+    fileName = fileName.slice(0, -4)
+  }
   const ext = path.extname(fileName)
   const encName = fileName.replace(ext, '')
   // encName don't need decodeURI
   let showName = decodeName(password, encType, encName)
   if (showName === null) {
-    showName = origPrefix + fileName
+    showName = origPrefix + rawFileName
   }
   return showName
 }

--- a/node-proxy/src/utils/commonUtil.ts
+++ b/node-proxy/src/utils/commonUtil.ts
@@ -19,7 +19,10 @@ export function convertRealName(password: string, encType: string, pathText: str
   const ext = path.extname(fileName)
   const encName = encodeName(password, encType, decodeURIComponent(fileName))
   console.log('@@decodeURI(fileName)', decodeURIComponent(fileName))
-  return encName + ext + (isWinZipAesEncType(encType) ? '.zip' : '')
+  if (isWinZipAesEncType(encType)) {
+    return encName + '.zip'
+  }
+  return encName + ext
 }
 
 // if file name has encrypt, return show name
@@ -29,8 +32,8 @@ export function convertShowName(password: string, encType: string, pathText: str
   if (isWinZipAesEncType(encType) && fileName.toLowerCase().endsWith('.zip')) {
     fileName = fileName.slice(0, -4)
   }
-  const ext = path.extname(fileName)
-  const encName = fileName.replace(ext, '')
+  const ext = isWinZipAesEncType(encType) ? '' : path.extname(fileName)
+  const encName = ext ? fileName.replace(ext, '') : fileName
   // encName don't need decodeURI
   let showName = decodeName(password, encType, encName)
   if (showName === null) {
@@ -40,6 +43,38 @@ export function convertShowName(password: string, encType: string, pathText: str
 }
 
 // 判断是否为匹配的路径
+export function isOrigName(fileName: string) {
+  return path.basename(fileName).indexOf(origPrefix) === 0
+}
+
+export function getOrigName(fileName: string) {
+  return path.basename(fileName).replace(origPrefix, '')
+}
+
+export function isEncryptedZipName(password: string, encType: string, fileName: string) {
+  if (!isWinZipAesEncType(encType)) return false
+  if (!String(fileName).toLowerCase().endsWith('.zip')) return false
+  const showName = convertShowName(password, encType, fileName)
+  return !!showName && !isOrigName(showName) && convertRealName(password, encType, showName) === path.basename(fileName)
+}
+
+export function isRawZipName(password: string, encType: string, fileName: string) {
+  return (
+    isWinZipAesEncType(encType) &&
+    String(fileName || '').toLowerCase().endsWith('.zip') &&
+    !isEncryptedZipName(password, encType, fileName)
+  )
+}
+
+export function getAListFileTypeByName(fileName = '') {
+  const ext = path.extname(String(fileName).split('?')[0]).toLowerCase()
+  if (['.mp4', '.m4v', '.webm', '.mkv', '.avi', '.mov', '.flv', '.wmv', '.ts', '.mpg', '.mpeg'].includes(ext)) return 2
+  if (['.mp3', '.m4a', '.aac', '.flac', '.wav', '.ogg'].includes(ext)) return 3
+  if (['.txt', '.md', '.json', '.js', '.ts', '.css', '.html', '.xml', '.log'].includes(ext)) return 4
+  if (['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.svg'].includes(ext)) return 5
+  return 0
+}
+
 export function pathExec(encPath: string[], url: string) {
   for (const filePath of encPath) {
     const result = pathToRegexp(new RegExp(filePath)).exec(url)

--- a/node-proxy/src/utils/flowEnc.js
+++ b/node-proxy/src/utils/flowEnc.js
@@ -3,11 +3,12 @@
 import MixEnc from './mixEnc'
 import Rc4Md5 from './rc4Md5'
 import AesCTR from './aesCTR'
+import WinZipAesZip, { isWinZipAesEncType } from './winZipAesZip'
 
 const cachePasswdOutward = {}
 
 class FlowEnc {
-  constructor(password, encryptType = 'mix', fileSize = 0) {
+  constructor(password, encryptType = 'mix', fileSize = 0, options = {}) {
     fileSize *= 1
     let encryptFlow = null
     if (encryptType === 'mix') {
@@ -25,7 +26,11 @@ class FlowEnc {
       encryptFlow = new AesCTR(password, fileSize)
       this.passwdOutward = encryptFlow.passwdOutward
     }
-    if (encryptType === null) {
+    if (isWinZipAesEncType(encryptType)) {
+      encryptFlow = new WinZipAesZip(password, fileSize, options)
+      this.passwdOutward = encryptFlow.passwdOutward
+    }
+    if (encryptFlow === null) {
       throw new Error('FlowEnc error')
     }
     cachePasswdOutward[password + encryptType] = this.passwdOutward

--- a/node-proxy/src/utils/httpClient.js
+++ b/node-proxy/src/utils/httpClient.js
@@ -13,6 +13,23 @@ const Agents = https.Agent
 const httpsAgent = new Agents({ keepAlive: true })
 const httpAgent = new Agent({ keepAlive: true })
 
+function prepareRedirectHeaders(request, redirectUrl) {
+  const sourceUrl = new URL(request.urlAddr)
+  const targetUrl = new URL(redirectUrl, sourceUrl)
+  delete request.headers.host
+  delete request.headers.Host
+  if (sourceUrl.host !== targetUrl.host) {
+    delete request.headers.authorization
+    delete request.headers.Authorization
+    delete request.headers.referer
+    delete request.headers.Referer
+  }
+  if (targetUrl.hostname.includes('baidupcs.com')) {
+    request.headers['User-Agent'] = 'pan.baidu.com'
+  }
+  request.urlAddr = targetUrl.toString()
+}
+
 export async function httpProxy(request, response, encryptTransform, decryptTransform) {
   const { method, headers, urlAddr, passwdInfo, url, fileSize } = request
   const reqId = randomUUID()
@@ -29,6 +46,21 @@ export async function httpProxy(request, response, encryptTransform, decryptTran
     // 处理重定向的请求，让下载的流量经过代理服务器
     const httpReq = httpRequest.request(urlAddr, options, async (httpResp) => {
       console.log('@@statusCode', reqId, httpResp.statusCode, httpResp.headers)
+      const redirectLocation = httpResp.headers.location || ''
+      if (
+        request.followRemoteRedirect &&
+        decryptTransform &&
+        httpResp.statusCode >= 300 &&
+        httpResp.statusCode < 400 &&
+        redirectLocation &&
+        (request.remoteRedirectCount || 0) < 5
+      ) {
+        httpResp.resume()
+        request.remoteRedirectCount = (request.remoteRedirectCount || 0) + 1
+        prepareRedirectHeaders(request, redirectLocation)
+        httpProxy(request, response, null, decryptTransform).then(resolve).catch(reject)
+        return
+      }
       response.statusCode = httpResp.statusCode
       if (response.statusCode % 300 < 5) {
         // 可能出现304，redirectUrl = undefined
@@ -61,11 +93,13 @@ export async function httpProxy(request, response, encryptTransform, decryptTran
       }
       applyWinZipAesResponseHeaders(response, request)
       // 下载时解密文件名
-      if (method === 'GET' && response.statusCode === 200 && passwdInfo && passwdInfo.enable && passwdInfo.encName) {
-        let fileName = decodeURIComponent(path.basename(url))
-        fileName = isWinZipAesEncType(passwdInfo.encType)
-          ? convertShowName(passwdInfo.password, passwdInfo.encType, fileName)
-          : decodeName(passwdInfo.password, passwdInfo.encType, fileName.replace(path.extname(fileName), ''))
+      if (method === 'GET' && response.statusCode < 300 && passwdInfo && passwdInfo.enable && passwdInfo.encName) {
+        let fileName = request.zipVirtualName || decodeURIComponent(path.basename(url))
+        if (!request.zipVirtualName) {
+          fileName = isWinZipAesEncType(passwdInfo.encType)
+            ? convertShowName(passwdInfo.password, passwdInfo.encType, fileName)
+            : decodeName(passwdInfo.password, passwdInfo.encType, fileName.replace(path.extname(fileName), ''))
+        }
         if (fileName) {
           let cd = response.getHeader('content-disposition')
           cd = cd ? cd.replace(/filename\*?=[^=;]*;?/g, '') : ''
@@ -90,7 +124,11 @@ export async function httpProxy(request, response, encryptTransform, decryptTran
       console.log('@@httpProxy request error ', reqId, err, urlAddr, headers)
     })
     // 是否需要加密
-    encryptTransform ? request.pipe(encryptTransform).pipe(httpReq) : request.pipe(httpReq)
+    if (request.followRemoteRedirect && ['GET', 'HEAD'].includes(String(method).toLocaleUpperCase())) {
+      httpReq.end()
+    } else {
+      encryptTransform ? request.pipe(encryptTransform).pipe(httpReq) : request.pipe(httpReq)
+    }
     // 重定向的请求 关闭时 关闭被重定向的请求
     response.on('close', () => {
       console.log('@本地响应关闭...', reqId, url)

--- a/node-proxy/src/utils/httpClient.js
+++ b/node-proxy/src/utils/httpClient.js
@@ -3,7 +3,8 @@ import https from 'node:https'
 import crypto, { randomUUID } from 'crypto'
 import levelDB from './levelDB'
 import path from 'path'
-import { decodeName } from './commonUtil'
+import { convertShowName, decodeName } from './commonUtil'
+import { applyWinZipAesResponseHeaders, isWinZipAesEncType, serializeWinZipAesZipInfo } from './winZipAesZip'
 // import { pathExec } from './commonUtil'
 const Agent = http.Agent
 const Agents = https.Agent
@@ -36,7 +37,17 @@ export async function httpProxy(request, response, encryptTransform, decryptTran
         if (decryptTransform && passwdInfo.enable) {
           const key = crypto.randomUUID()
           console.log()
-          await levelDB.setExpire(key, { redirectUrl, passwdInfo, fileSize }, 60 * 60 * 72) // 缓存起来，默认3天，足够下载和观看了
+          await levelDB.setExpire(
+            key,
+            {
+              redirectUrl,
+              passwdInfo,
+              fileSize,
+              virtualName: request.zipVirtualName,
+              zipInfo: serializeWinZipAesZipInfo(request.zipInfo),
+            },
+            60 * 60 * 72
+          ) // 缓存起来，默认3天，足够下载和观看了
           // 、Referer
           httpResp.headers.location = `/redirect/${key}?decode=1&lastUrl=${encodeURIComponent(url)}`
         }
@@ -48,10 +59,13 @@ export async function httpProxy(request, response, encryptTransform, decryptTran
       for (const key in httpResp.headers) {
         response.setHeader(key, httpResp.headers[key])
       }
+      applyWinZipAesResponseHeaders(response, request)
       // 下载时解密文件名
       if (method === 'GET' && response.statusCode === 200 && passwdInfo && passwdInfo.enable && passwdInfo.encName) {
         let fileName = decodeURIComponent(path.basename(url))
-        fileName = decodeName(passwdInfo.password, passwdInfo.encType, fileName.replace(path.extname(fileName), ''))
+        fileName = isWinZipAesEncType(passwdInfo.encType)
+          ? convertShowName(passwdInfo.password, passwdInfo.encType, fileName)
+          : decodeName(passwdInfo.password, passwdInfo.encType, fileName.replace(path.extname(fileName), ''))
         if (fileName) {
           let cd = response.getHeader('content-disposition')
           cd = cd ? cd.replace(/filename\*?=[^=;]*;?/g, '') : ''

--- a/node-proxy/src/utils/levelDB.js
+++ b/node-proxy/src/utils/levelDB.js
@@ -48,7 +48,7 @@ class Nedb {
 const nedb = new Nedb(process.cwd() + '/conf/nedb/datafile')
 
 // 定时清除过期的数据
-setInterval(async () => {
+const expireTimer = setInterval(async () => {
   const allData = await nedb.datastore.find({})
   for (const data of allData) {
     const { key, expire } = data
@@ -58,5 +58,6 @@ setInterval(async () => {
     }
   }
 }, 30 * 1000)
+expireTimer.unref && expireTimer.unref()
 
 export default nedb

--- a/node-proxy/src/utils/winZipAesZip.js
+++ b/node-proxy/src/utils/winZipAesZip.js
@@ -675,6 +675,69 @@ export async function parseWinZipAesZipInfoFromReader(readRange, totalSize) {
   }
 }
 
+export async function parseManagedWinZipAesZipInfoFromReader(readRange, totalSize) {
+  const firstSize = Math.min(4096, totalSize)
+  let first = await readRange(0, firstSize)
+  const ensureFirstBytes = async (length) => {
+    if (first.length >= length) return first.subarray(0, length)
+    const next = await readRange(first.length, length - first.length)
+    first = Buffer.concat([first, next])
+    return first.subarray(0, length)
+  }
+
+  const fixed = await ensureFirstBytes(30)
+  if (fixed.length < 30 || fixed.readUInt32LE(0) !== 0x04034b50) {
+    throw new Error('ZIP local header is invalid')
+  }
+  const nameLen = fixed.readUInt16LE(26)
+  const extraLen = fixed.readUInt16LE(28)
+  const headerSize = 30 + nameLen + extraLen
+  const header = await ensureFirstBytes(headerSize)
+  const local = parseLocalHeaderBytes(fixed, header.subarray(30, headerSize), 0)
+  const winZipAes = parseWinZipAesExtra(local.extra)
+  if (!winZipAes) {
+    throw new Error('WinZip AES extra field not found')
+  }
+  if (winZipAes.vendor !== WINZIP_AES_VENDOR.toString('ascii')) {
+    throw new Error('WinZip AES vendor is invalid')
+  }
+  if ((local.flags & 1) === 0) {
+    throw new Error('ZIP entry is not encrypted')
+  }
+  if (local.method !== WINZIP_AES_METHOD) {
+    throw new Error('ZIP entry is not WinZip AES')
+  }
+  if (winZipAes.actualMethod !== STORE_METHOD) {
+    throw new Error('WinZip AES playback requires store method')
+  }
+
+  const saltLen = winZipAesSaltSize(winZipAes.strength)
+  const dataHeaderSize = saltLen + WINZIP_AES_VERIFY_SIZE
+  const authSize = WINZIP_AES_AUTH_SIZE
+  const plainSize = local.uncompressedSize
+  const compressedSize = local.compressedSize
+  if (compressedSize - dataHeaderSize - authSize !== plainSize) {
+    throw new Error('WinZip-AES-CTR ZIP is not store-compatible')
+  }
+  const saltOffset = local.headerSize
+  const saltBytes = await ensureFirstBytes(saltOffset + saltLen)
+  return {
+    encType: ZIP_AES_ENC_TYPE,
+    innerName: local.name || INNER_FILENAME,
+    salt: saltBytes.subarray(saltOffset, saltOffset + saltLen),
+    winZipAes,
+    headerSize: local.headerSize,
+    localHeaderOffset: 0,
+    payloadOffset: saltOffset + dataHeaderSize,
+    payloadSize: plainSize,
+    authTagOffset: saltOffset + compressedSize - authSize,
+    authSize,
+    plainSize,
+    compressedSize,
+    totalSize,
+  }
+}
+
 export async function parseWinZipAesZipInfoFromFile(filePath) {
   const fs = await import('fs')
   const stat = await fs.promises.stat(filePath)
@@ -691,10 +754,32 @@ export async function parseWinZipAesZipInfoFromFile(filePath) {
   }
 }
 
+export async function parseManagedWinZipAesZipInfoFromFile(filePath) {
+  const fs = await import('fs')
+  const stat = await fs.promises.stat(filePath)
+  const handle = await fs.promises.open(filePath, 'r')
+  try {
+    const readRange = async (start, length) => {
+      const buffer = Buffer.alloc(length)
+      const result = await handle.read(buffer, 0, length, start)
+      return buffer.subarray(0, result.bytesRead)
+    }
+    return await parseManagedWinZipAesZipInfoFromReader(readRange, stat.size)
+  } finally {
+    await handle.close()
+  }
+}
+
 export async function parseWinZipAesZipInfoFromRemote(urlAddr, headers = {}, candidateSize = 0, options = {}) {
   const totalSize = await getRemoteSize(urlAddr, headers, Number(candidateSize) || 0, options)
   const readRange = (start, length) => readRemoteRange(urlAddr, headers, start, length, options)
   return await parseWinZipAesZipInfoFromReader(readRange, totalSize)
+}
+
+export async function parseManagedWinZipAesZipInfoFromRemote(urlAddr, headers = {}, candidateSize = 0, options = {}) {
+  const totalSize = await getRemoteSize(urlAddr, headers, Number(candidateSize) || 0, options)
+  const readRange = (start, length) => readRemoteRange(urlAddr, headers, start, length, options)
+  return await parseManagedWinZipAesZipInfoFromReader(readRange, totalSize)
 }
 
 export function isWinZipAesEncType(encType) {

--- a/node-proxy/src/utils/winZipAesZip.js
+++ b/node-proxy/src/utils/winZipAesZip.js
@@ -1,0 +1,848 @@
+import crypto from 'crypto'
+import http from 'http'
+import https from 'node:https'
+import path from 'path'
+import { Transform } from 'stream'
+
+export const ZIP_AES_ENC_TYPE = 'winzip-aes-ctr'
+
+const ZIP64_EXTRA_ID = 0x0001
+const WINZIP_AES_EXTRA_ID = 0x9901
+const WINZIP_AES_METHOD = 99
+const STORE_METHOD = 0
+const ZIP32_MAX = 0xffffffff
+const ZIP_AES_VERSION_NEEDED = 51
+const ZIP_AES_FLAGS = 0x0001 | 0x0800
+const WINZIP_AES_VERSION = 2
+const WINZIP_AES_STRENGTH = 3
+const WINZIP_AES_VENDOR = Buffer.from('AE', 'ascii')
+const WINZIP_AES_SALT_SIZE = 16
+const WINZIP_AES_VERIFY_SIZE = 2
+const WINZIP_AES_AUTH_SIZE = 10
+const WINZIP_AES_PBKDF2_ITERATIONS = 1000
+const FIXED_DOS_TIME = 0x4800
+const FIXED_DOS_DATE = 0x5a2a
+const INNER_FILENAME = 'payload.bin'
+
+const MIME_MAP = {
+  '.mp4': 'video/mp4',
+  '.m4v': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mkv': 'video/x-matroska',
+  '.avi': 'video/x-msvideo',
+  '.mov': 'video/quicktime',
+  '.flv': 'video/x-flv',
+  '.wmv': 'video/x-ms-wmv',
+  '.ts': 'video/mp2t',
+  '.mpg': 'video/mpeg',
+  '.mpeg': 'video/mpeg',
+  '.mp3': 'audio/mpeg',
+  '.m4a': 'audio/mp4',
+  '.aac': 'audio/aac',
+  '.flac': 'audio/flac',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.txt': 'text/plain; charset=utf-8',
+  '.pdf': 'application/pdf',
+}
+
+function readUInt64LE(buffer, offset) {
+  const value = buffer.readBigUInt64LE(offset)
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error('zip file is too large for javascript number precision')
+  }
+  return Number(value)
+}
+
+function uint64Buffer(value) {
+  const buffer = Buffer.alloc(8)
+  buffer.writeBigUInt64LE(BigInt(value), 0)
+  return buffer
+}
+
+function isZip64Needed(plainSize, compressedSize = plainSize, localHeaderOffset = 0, centralOffset = 0, centralSize = 0) {
+  return (
+    plainSize >= ZIP32_MAX ||
+    compressedSize >= ZIP32_MAX ||
+    localHeaderOffset >= ZIP32_MAX ||
+    centralOffset >= ZIP32_MAX ||
+    centralSize >= ZIP32_MAX
+  )
+}
+
+function safeDecodeURIComponent(value) {
+  try {
+    return decodeURIComponent(value)
+  } catch (e) {
+    return value
+  }
+}
+
+function normalizeName(name) {
+  return path.basename(safeDecodeURIComponent(name || INNER_FILENAME)) || INNER_FILENAME
+}
+
+function getInnerName(name) {
+  const ext = path.extname(normalizeName(name)).toLowerCase()
+  return `payload${ext || '.bin'}`
+}
+
+function deriveOutwardPassword(password) {
+  if (String(password || '').length === 32) {
+    return password
+  }
+  return crypto.pbkdf2Sync(String(password || ''), 'ZIP-AES-CTR', 1000, 16, 'sha256').toString('hex')
+}
+
+function winZipAesKeySize(strength) {
+  if (strength === 1) return 16
+  if (strength === 2) return 24
+  if (strength === 3) return 32
+  throw new Error('unsupported WinZip AES strength')
+}
+
+function deriveWinZipAesKeys(password, salt, strength = WINZIP_AES_STRENGTH) {
+  const keySize = winZipAesKeySize(strength)
+  const material = crypto.pbkdf2Sync(
+    Buffer.from(String(password || ''), 'utf8'),
+    salt,
+    WINZIP_AES_PBKDF2_ITERATIONS,
+    keySize * 2 + WINZIP_AES_VERIFY_SIZE,
+    'sha1'
+  )
+  return {
+    encKey: material.subarray(0, keySize),
+    macKey: material.subarray(keySize, keySize * 2),
+    verifier: material.subarray(keySize * 2),
+  }
+}
+
+function incrementLittleEndianCounter(counter) {
+  for (let i = 0; i < counter.length; i++) {
+    counter[i] = (counter[i] + 1) & 0xff
+    if (counter[i] !== 0) break
+  }
+}
+
+function createWinZipAesCtr(key, position = 0) {
+  const blockIndex = Math.trunc(Number(position || 0) / 16)
+  let offset = 16
+  let initialOffset = Math.trunc(Number(position || 0) % 16)
+  const counter = Buffer.alloc(16)
+  counter.writeBigUInt64LE(BigInt(blockIndex + 1), 0)
+  const ecb = crypto.createCipheriv(`aes-${key.length * 8}-ecb`, key, null)
+  ecb.setAutoPadding(false)
+  let keystream = Buffer.alloc(0)
+
+  function nextKeyByte() {
+    if (offset >= keystream.length) {
+      keystream = ecb.update(counter)
+      incrementLittleEndianCounter(counter)
+      offset = initialOffset
+      initialOffset = 0
+    }
+    return keystream[offset++]
+  }
+
+  return {
+    update(data) {
+      const output = Buffer.alloc(data.length)
+      for (let i = 0; i < data.length; i++) {
+        output[i] = data[i] ^ nextKeyByte()
+      }
+      return output
+    },
+    final() {
+      ecb.final()
+      return Buffer.alloc(0)
+    },
+  }
+}
+
+function buildZip64Extra(values) {
+  const parts = []
+  if (values.uncompressedSize !== undefined) parts.push(uint64Buffer(values.uncompressedSize))
+  if (values.compressedSize !== undefined) parts.push(uint64Buffer(values.compressedSize))
+  if (values.localHeaderOffset !== undefined) parts.push(uint64Buffer(values.localHeaderOffset))
+  const body = Buffer.concat(parts)
+  const field = Buffer.alloc(4 + body.length)
+  field.writeUInt16LE(ZIP64_EXTRA_ID, 0)
+  field.writeUInt16LE(body.length, 2)
+  body.copy(field, 4)
+  return field
+}
+
+function parseZip64Sizes(extra, need) {
+  const result = {}
+  const field = parseExtraFields(extra).find((item) => item.id === ZIP64_EXTRA_ID)
+  if (!field) return result
+
+  let offset = 0
+  if (need.uncompressedSize && offset + 8 <= field.data.length) {
+    result.uncompressedSize = readUInt64LE(field.data, offset)
+    offset += 8
+  }
+  if (need.compressedSize && offset + 8 <= field.data.length) {
+    result.compressedSize = readUInt64LE(field.data, offset)
+    offset += 8
+  }
+  if (need.localHeaderOffset && offset + 8 <= field.data.length) {
+    result.localHeaderOffset = readUInt64LE(field.data, offset)
+  }
+  return result
+}
+
+function buildWinZipAesExtra() {
+  const body = Buffer.alloc(7)
+  body.writeUInt16LE(WINZIP_AES_VERSION, 0)
+  WINZIP_AES_VENDOR.copy(body, 2)
+  body.writeUInt8(WINZIP_AES_STRENGTH, 4)
+  body.writeUInt16LE(STORE_METHOD, 5)
+  const field = Buffer.alloc(4 + body.length)
+  field.writeUInt16LE(WINZIP_AES_EXTRA_ID, 0)
+  field.writeUInt16LE(body.length, 2)
+  body.copy(field, 4)
+  return field
+}
+
+function parseExtraFields(extra) {
+  const fields = []
+  let offset = 0
+  while (offset + 4 <= extra.length) {
+    const id = extra.readUInt16LE(offset)
+    const size = extra.readUInt16LE(offset + 2)
+    const dataStart = offset + 4
+    const dataEnd = dataStart + size
+    if (dataEnd > extra.length) break
+    fields.push({ id, data: extra.subarray(dataStart, dataEnd) })
+    offset = dataEnd
+  }
+  return fields
+}
+
+function parseWinZipAesExtra(extra) {
+  const field = parseExtraFields(extra).find((item) => item.id === WINZIP_AES_EXTRA_ID)
+  if (!field || field.data.length !== 7) return null
+  return {
+    version: field.data.readUInt16LE(0),
+    vendor: field.data.subarray(2, 4).toString('ascii'),
+    strength: field.data.readUInt8(4),
+    actualMethod: field.data.readUInt16LE(5),
+  }
+}
+
+function winZipAesSaltSize(strength) {
+  if (strength === 1) return 8
+  if (strength === 2) return 12
+  if (strength === 3) return 16
+  throw new Error('unsupported WinZip AES strength')
+}
+
+function buildLocalHeader({ plainSize, compressedSize, innerName }) {
+  const fileName = Buffer.from(innerName || INNER_FILENAME, 'utf8')
+  const zip64 = isZip64Needed(plainSize, compressedSize)
+  const extra = zip64
+    ? Buffer.concat([buildZip64Extra({ uncompressedSize: plainSize, compressedSize }), buildWinZipAesExtra()])
+    : buildWinZipAesExtra()
+  const header = Buffer.alloc(30)
+  header.writeUInt32LE(0x04034b50, 0)
+  header.writeUInt16LE(ZIP_AES_VERSION_NEEDED, 4)
+  header.writeUInt16LE(ZIP_AES_FLAGS, 6)
+  header.writeUInt16LE(WINZIP_AES_METHOD, 8)
+  header.writeUInt16LE(FIXED_DOS_TIME, 10)
+  header.writeUInt16LE(FIXED_DOS_DATE, 12)
+  header.writeUInt32LE(0, 14)
+  header.writeUInt32LE(zip64 ? ZIP32_MAX : compressedSize, 18)
+  header.writeUInt32LE(zip64 ? ZIP32_MAX : plainSize, 22)
+  header.writeUInt16LE(fileName.length, 26)
+  header.writeUInt16LE(extra.length, 28)
+  return Buffer.concat([header, fileName, extra])
+}
+
+function buildCentralDirectory({ plainSize, compressedSize, innerName, localHeaderOffset, centralOffset }) {
+  const fileName = Buffer.from(innerName || INNER_FILENAME, 'utf8')
+  const zip64 = isZip64Needed(plainSize, compressedSize, localHeaderOffset, centralOffset)
+  const extra = zip64
+    ? Buffer.concat([
+        buildZip64Extra({
+          uncompressedSize: plainSize,
+          compressedSize,
+          localHeaderOffset,
+        }),
+        buildWinZipAesExtra(),
+      ])
+    : buildWinZipAesExtra()
+  const header = Buffer.alloc(46)
+  header.writeUInt32LE(0x02014b50, 0)
+  header.writeUInt16LE(ZIP_AES_VERSION_NEEDED, 4)
+  header.writeUInt16LE(ZIP_AES_VERSION_NEEDED, 6)
+  header.writeUInt16LE(ZIP_AES_FLAGS, 8)
+  header.writeUInt16LE(WINZIP_AES_METHOD, 10)
+  header.writeUInt16LE(FIXED_DOS_TIME, 12)
+  header.writeUInt16LE(FIXED_DOS_DATE, 14)
+  header.writeUInt32LE(0, 16)
+  header.writeUInt32LE(zip64 ? ZIP32_MAX : compressedSize, 20)
+  header.writeUInt32LE(zip64 ? ZIP32_MAX : plainSize, 24)
+  header.writeUInt16LE(fileName.length, 28)
+  header.writeUInt16LE(extra.length, 30)
+  header.writeUInt16LE(0, 32)
+  header.writeUInt16LE(0, 34)
+  header.writeUInt16LE(0, 36)
+  header.writeUInt32LE(0, 38)
+  header.writeUInt32LE(zip64 ? ZIP32_MAX : localHeaderOffset, 42)
+  return Buffer.concat([header, fileName, extra])
+}
+
+function buildEndRecords({ centralOffset, centralSize, zip64 }) {
+  const records = []
+  if (zip64) {
+    const zip64EocdOffset = centralOffset + centralSize
+    const zip64Eocd = Buffer.alloc(56)
+    zip64Eocd.writeUInt32LE(0x06064b50, 0)
+    zip64Eocd.writeBigUInt64LE(BigInt(44), 4)
+    zip64Eocd.writeUInt16LE(ZIP_AES_VERSION_NEEDED, 12)
+    zip64Eocd.writeUInt16LE(ZIP_AES_VERSION_NEEDED, 14)
+    zip64Eocd.writeUInt32LE(0, 16)
+    zip64Eocd.writeUInt32LE(0, 20)
+    zip64Eocd.writeBigUInt64LE(BigInt(1), 24)
+    zip64Eocd.writeBigUInt64LE(BigInt(1), 32)
+    zip64Eocd.writeBigUInt64LE(BigInt(centralSize), 40)
+    zip64Eocd.writeBigUInt64LE(BigInt(centralOffset), 48)
+    records.push(zip64Eocd)
+
+    const locator = Buffer.alloc(20)
+    locator.writeUInt32LE(0x07064b50, 0)
+    locator.writeUInt32LE(0, 4)
+    locator.writeBigUInt64LE(BigInt(zip64EocdOffset), 8)
+    locator.writeUInt32LE(1, 16)
+    records.push(locator)
+  }
+
+  const eocd = Buffer.alloc(22)
+  eocd.writeUInt32LE(0x06054b50, 0)
+  eocd.writeUInt16LE(0, 4)
+  eocd.writeUInt16LE(0, 6)
+  eocd.writeUInt16LE(zip64 ? 0xffff : 1, 8)
+  eocd.writeUInt16LE(zip64 ? 0xffff : 1, 10)
+  eocd.writeUInt32LE(zip64 ? ZIP32_MAX : centralSize, 12)
+  eocd.writeUInt32LE(zip64 ? ZIP32_MAX : centralOffset, 16)
+  eocd.writeUInt16LE(0, 20)
+  records.push(eocd)
+  return Buffer.concat(records)
+}
+
+function buildLayout({ plainSize, originalName, innerName }) {
+  const zipInnerName = innerName || getInnerName(originalName)
+  const compressedSize = Number(plainSize || 0) + WINZIP_AES_SALT_SIZE + WINZIP_AES_VERIFY_SIZE + WINZIP_AES_AUTH_SIZE
+  const header = buildLocalHeader({ plainSize, compressedSize, innerName: zipInnerName })
+  const centralOffset = header.length + compressedSize
+  const central = buildCentralDirectory({
+    plainSize,
+    compressedSize,
+    innerName: zipInnerName,
+    localHeaderOffset: 0,
+    centralOffset,
+  })
+  const zip64 = isZip64Needed(plainSize, compressedSize, 0, centralOffset, central.length)
+  const endRecords = buildEndRecords({ centralOffset, centralSize: central.length, zip64 })
+  return {
+    header,
+    central,
+    endRecords,
+    innerName: zipInnerName,
+    headerSize: header.length,
+    payloadOffset: header.length + WINZIP_AES_SALT_SIZE + WINZIP_AES_VERIFY_SIZE,
+    plainSize,
+    compressedSize,
+    packageSize: header.length + compressedSize + central.length + endRecords.length,
+  }
+}
+
+function parseRange(rangeHeader, totalSize) {
+  if (totalSize <= 0) {
+    return { hasRange: !!rangeHeader, start: 0, end: -1 }
+  }
+  if (!rangeHeader) {
+    return { hasRange: false, start: 0, end: Math.max(0, totalSize - 1) }
+  }
+  const rangeSpec = String(rangeHeader).replace(/bytes=/i, '').trim()
+  const [startText, endText] = rangeSpec.split('-')
+  let start
+  let end
+  if (!startText && endText) {
+    const suffixLength = Number(endText)
+    start = Math.max(0, totalSize - suffixLength)
+    end = totalSize - 1
+  } else {
+    start = Number(startText || 0)
+    end = endText ? Number(endText) : totalSize - 1
+  }
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start < 0 || start >= totalSize || end < start) {
+    throw new Error('invalid range request')
+  }
+  return { hasRange: true, start, end: Math.min(end, totalSize - 1) }
+}
+
+function sanitizeForwardHeaders(headers = {}, options = {}) {
+  const result = { ...headers }
+  delete result.host
+  delete result.range
+  delete result.Range
+  delete result['content-length']
+  delete result['content-range']
+  delete result['transfer-encoding']
+  delete result['accept-encoding']
+  if (options.stripAuth) {
+    delete result.authorization
+    delete result.Authorization
+    delete result.referer
+    delete result.Referer
+  }
+  return result
+}
+
+function requestBuffer(urlAddr, options, redirectCount = 0) {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(urlAddr)
+    const httpRequest = urlObj.protocol === 'https:' ? https : http
+    const { maxBytes, ...requestOptions } = options
+    const req = httpRequest.request(
+      urlObj,
+      {
+        ...requestOptions,
+        rejectUnauthorized: false,
+      },
+      (resp) => {
+        const location = resp.headers.location
+        if (resp.statusCode >= 300 && resp.statusCode < 400 && location && redirectCount < 5) {
+          resp.resume()
+          const nextUrl = new URL(location, urlObj).toString()
+          const nextOptions = { ...options, headers: { ...(options.headers || {}) } }
+          delete nextOptions.headers.host
+          delete nextOptions.headers.authorization
+          delete nextOptions.headers.referer
+          requestBuffer(nextUrl, nextOptions, redirectCount + 1).then(resolve).catch(reject)
+          return
+        }
+        const chunks = []
+        let total = 0
+        resp.on('data', (chunk) => {
+          total += chunk.length
+          if (maxBytes && total > maxBytes) {
+            req.destroy(new Error('remote response exceeded expected range size'))
+            return
+          }
+          chunks.push(chunk)
+        })
+        resp.on('end', () => resolve({ statusCode: resp.statusCode, headers: resp.headers, body: Buffer.concat(chunks), url: urlAddr }))
+      }
+    )
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+async function getRemoteSize(urlAddr, headers, candidateSize = 0, options = {}) {
+  if (candidateSize > 0) return candidateSize
+  const cleanHeaders = sanitizeForwardHeaders(headers, options)
+  try {
+    const head = await requestBuffer(urlAddr, { method: 'HEAD', headers: cleanHeaders })
+    const contentLength = Number(head.headers['content-length'])
+    if (head.statusCode >= 200 && head.statusCode < 300 && Number.isFinite(contentLength) && contentLength > 0) {
+      return contentLength
+    }
+  } catch (e) {}
+
+  try {
+    const resp = await requestBuffer(urlAddr, {
+      method: 'GET',
+      headers: { ...cleanHeaders, Range: 'bytes=0-0' },
+    })
+    const contentRange = resp.headers['content-range'] || ''
+    const total = Number(String(contentRange).split('/')[1])
+    if (resp.statusCode === 206 && Number.isFinite(total) && total > 0) {
+      return total
+    }
+    const contentLength = Number(resp.headers['content-length'])
+    if (resp.statusCode === 200 && Number.isFinite(contentLength) && contentLength > 0) {
+      return contentLength
+    }
+  } catch (e) {}
+  throw new Error('unable to detect remote WinZip-AES-CTR ZIP size')
+}
+
+async function readRemoteRange(urlAddr, headers, start, length, options = {}) {
+  const end = start + length - 1
+  const cleanHeaders = sanitizeForwardHeaders(headers, options)
+  const resp = await requestBuffer(urlAddr, {
+    method: 'GET',
+    headers: { ...cleanHeaders, Range: `bytes=${start}-${end}` },
+    maxBytes: length,
+  })
+  if (resp.statusCode === 206) {
+    return resp.body
+  }
+  throw new Error(`remote range request failed: ${resp.statusCode}`)
+}
+
+async function parseEocd(tail, tailStart, readRange) {
+  const eocdSig = Buffer.from([0x50, 0x4b, 0x05, 0x06])
+  let pos = -1
+  for (let i = tail.length - 22; i >= 0; i--) {
+    if (tail.subarray(i, i + 4).equals(eocdSig)) {
+      const commentLen = tail.readUInt16LE(i + 20)
+      if (i + 22 + commentLen === tail.length) {
+        pos = i
+        break
+      }
+    }
+  }
+  if (pos < 0 || pos + 22 > tail.length) {
+    throw new Error('ZIP EOCD not found')
+  }
+  const eocd = tail.subarray(pos, pos + 22)
+  let entryCount = eocd.readUInt16LE(10)
+  let centralSize = eocd.readUInt32LE(12)
+  let centralOffset = eocd.readUInt32LE(16)
+  const needsZip64 = centralSize === ZIP32_MAX || centralOffset === ZIP32_MAX || eocd.readUInt16LE(8) === 0xffff
+
+  if (!needsZip64) {
+    return { centralOffset, centralSize, entryCount }
+  }
+
+  const locatorSig = Buffer.from([0x50, 0x4b, 0x06, 0x07])
+  const locatorPos = tail.lastIndexOf(locatorSig, pos)
+  if (locatorPos < 0 || locatorPos + 20 > tail.length) {
+    throw new Error('ZIP64 locator not found')
+  }
+  const zip64EocdOffset = readUInt64LE(tail, locatorPos + 8)
+  let zip64Eocd
+  const offsetInTail = zip64EocdOffset - tailStart
+  if (offsetInTail >= 0 && offsetInTail + 56 <= tail.length) {
+    zip64Eocd = tail.subarray(offsetInTail, offsetInTail + 56)
+  } else {
+    zip64Eocd = await readRange(zip64EocdOffset, 56)
+  }
+  if (zip64Eocd.readUInt32LE(0) !== 0x06064b50) {
+    throw new Error('ZIP64 EOCD is invalid')
+  }
+  entryCount = readUInt64LE(zip64Eocd, 32)
+  centralSize = readUInt64LE(zip64Eocd, 40)
+  centralOffset = readUInt64LE(zip64Eocd, 48)
+  return { centralOffset, centralSize, entryCount }
+}
+
+function parseLocalHeaderBytes(fixed, rest, localHeaderOffset) {
+  const compressedSize32 = fixed.readUInt32LE(18)
+  const uncompressedSize32 = fixed.readUInt32LE(22)
+  const nameLen = fixed.readUInt16LE(26)
+  const extraLen = fixed.readUInt16LE(28)
+  const name = rest.subarray(0, nameLen).toString('utf8')
+  const extra = rest.subarray(nameLen, nameLen + extraLen)
+  const zip64 = parseZip64Sizes(extra, {
+    uncompressedSize: uncompressedSize32 === ZIP32_MAX,
+    compressedSize: compressedSize32 === ZIP32_MAX,
+  })
+  return {
+    method: fixed.readUInt16LE(8),
+    flags: fixed.readUInt16LE(6),
+    compressedSize: zip64.compressedSize ?? compressedSize32,
+    uncompressedSize: zip64.uncompressedSize ?? uncompressedSize32,
+    localHeaderOffset,
+    name,
+    extra,
+    headerSize: 30 + nameLen + extraLen,
+  }
+}
+
+async function parseLocalHeader(readRange, localHeaderOffset) {
+  const fixed = await readRange(localHeaderOffset, 30)
+  if (fixed.length < 30 || fixed.readUInt32LE(0) !== 0x04034b50) {
+    throw new Error('ZIP local header is invalid')
+  }
+  const nameLen = fixed.readUInt16LE(26)
+  const extraLen = fixed.readUInt16LE(28)
+  const rest = await readRange(localHeaderOffset + 30, nameLen + extraLen)
+  return parseLocalHeaderBytes(fixed, rest, localHeaderOffset)
+}
+
+async function parseCentralDirectory(readRange, centralOffset) {
+  const fixed = await readRange(centralOffset, 46)
+  if (fixed.length < 46 || fixed.readUInt32LE(0) !== 0x02014b50) {
+    throw new Error('ZIP central directory header is invalid')
+  }
+  const compressedSize32 = fixed.readUInt32LE(20)
+  const uncompressedSize32 = fixed.readUInt32LE(24)
+  const nameLen = fixed.readUInt16LE(28)
+  const extraLen = fixed.readUInt16LE(30)
+  const commentLen = fixed.readUInt16LE(32)
+  const localHeaderOffset32 = fixed.readUInt32LE(42)
+  const rest = await readRange(centralOffset + 46, nameLen + extraLen + commentLen)
+  const name = rest.subarray(0, nameLen).toString('utf8')
+  const extra = rest.subarray(nameLen, nameLen + extraLen)
+  const zip64 = parseZip64Sizes(extra, {
+    uncompressedSize: uncompressedSize32 === ZIP32_MAX,
+    compressedSize: compressedSize32 === ZIP32_MAX,
+    localHeaderOffset: localHeaderOffset32 === ZIP32_MAX,
+  })
+  return {
+    method: fixed.readUInt16LE(10),
+    flags: fixed.readUInt16LE(8),
+    compressedSize: zip64.compressedSize ?? compressedSize32,
+    uncompressedSize: zip64.uncompressedSize ?? uncompressedSize32,
+    localHeaderOffset: zip64.localHeaderOffset ?? localHeaderOffset32,
+    name,
+    extra,
+  }
+}
+
+export async function parseWinZipAesZipInfoFromReader(readRange, totalSize) {
+  const tailSize = Math.min(65536 + 128, totalSize)
+  const tailStart = Math.max(0, totalSize - tailSize)
+  const tail = await readRange(tailStart, totalSize - tailStart)
+  const { centralOffset, entryCount } = await parseEocd(tail, tailStart, readRange)
+  if (entryCount !== 1) {
+    throw new Error('WinZip AES playback supports single-file ZIP only')
+  }
+  const central = await parseCentralDirectory(readRange, centralOffset)
+  const local = await parseLocalHeader(readRange, central.localHeaderOffset)
+  const winZipAes = parseWinZipAesExtra(central.extra) || parseWinZipAesExtra(local.extra)
+  if (!winZipAes) {
+    throw new Error('WinZip AES extra field not found')
+  }
+  if (winZipAes.vendor !== WINZIP_AES_VENDOR.toString('ascii')) {
+    throw new Error('WinZip AES vendor is invalid')
+  }
+  if ((central.flags & 1) === 0 || (local.flags & 1) === 0) {
+    throw new Error('ZIP entry is not encrypted')
+  }
+  if (central.method !== WINZIP_AES_METHOD || local.method !== WINZIP_AES_METHOD) {
+    throw new Error('ZIP entry is not WinZip AES')
+  }
+  if (winZipAes.actualMethod !== STORE_METHOD) {
+    throw new Error('WinZip AES playback requires store method')
+  }
+  const saltLen = winZipAesSaltSize(winZipAes.strength)
+  const dataHeaderSize = saltLen + WINZIP_AES_VERIFY_SIZE
+  const authSize = WINZIP_AES_AUTH_SIZE
+  const plainSize = central.uncompressedSize
+  const compressedSize = central.compressedSize
+  if (compressedSize - dataHeaderSize - authSize !== plainSize) {
+    throw new Error('WinZip-AES-CTR ZIP is not store-compatible')
+  }
+  const saltOffset = local.localHeaderOffset + local.headerSize
+  const salt = await readRange(saltOffset, saltLen)
+  return {
+    encType: ZIP_AES_ENC_TYPE,
+    innerName: central.name || local.name || INNER_FILENAME,
+    salt,
+    winZipAes,
+    headerSize: local.headerSize,
+    localHeaderOffset: local.localHeaderOffset,
+    payloadOffset: saltOffset + dataHeaderSize,
+    payloadSize: plainSize,
+    authTagOffset: saltOffset + compressedSize - authSize,
+    authSize,
+    plainSize,
+    compressedSize,
+    totalSize,
+  }
+}
+
+export async function parseWinZipAesZipInfoFromFile(filePath) {
+  const fs = await import('fs')
+  const stat = await fs.promises.stat(filePath)
+  const handle = await fs.promises.open(filePath, 'r')
+  try {
+    const readRange = async (start, length) => {
+      const buffer = Buffer.alloc(length)
+      const result = await handle.read(buffer, 0, length, start)
+      return buffer.subarray(0, result.bytesRead)
+    }
+    return await parseWinZipAesZipInfoFromReader(readRange, stat.size)
+  } finally {
+    await handle.close()
+  }
+}
+
+export async function parseWinZipAesZipInfoFromRemote(urlAddr, headers = {}, candidateSize = 0, options = {}) {
+  const totalSize = await getRemoteSize(urlAddr, headers, Number(candidateSize) || 0, options)
+  const readRange = (start, length) => readRemoteRange(urlAddr, headers, start, length, options)
+  return await parseWinZipAesZipInfoFromReader(readRange, totalSize)
+}
+
+export function isWinZipAesEncType(encType) {
+  return encType === ZIP_AES_ENC_TYPE
+}
+
+export function serializeWinZipAesZipInfo(zipInfo) {
+  if (!zipInfo) return null
+  return {
+    ...zipInfo,
+    salt: zipInfo.salt ? Buffer.from(zipInfo.salt).toString('hex') : undefined,
+  }
+}
+
+export function deserializeWinZipAesZipInfo(zipInfo) {
+  if (!zipInfo) return null
+  return {
+    ...zipInfo,
+    salt: zipInfo.salt ? Buffer.from(zipInfo.salt, 'hex') : undefined,
+  }
+}
+
+export function getMimeByName(name = '') {
+  let fileName = String(name).split('?')[0]
+  if (fileName.toLowerCase().endsWith('.zip')) {
+    fileName = fileName.slice(0, -4)
+  }
+  const ext = path.extname(fileName).toLowerCase()
+  return MIME_MAP[ext] || 'application/octet-stream'
+}
+
+export function prepareWinZipAesDownloadRequest(request, zipInfo, clientRangeHeader) {
+  const plainRange = parseRange(clientRangeHeader, zipInfo.plainSize)
+  request.zipInfo = zipInfo
+  request.zipPlainRange = plainRange
+  request.zipCipherStart = plainRange.start
+  delete request.headers['accept-encoding']
+
+  if (request.method.toLocaleUpperCase() !== 'HEAD') {
+    const start = zipInfo.payloadOffset + plainRange.start
+    const end = zipInfo.payloadOffset + plainRange.end
+    request.zipPackageRange = { start, end }
+    request.headers.range = `bytes=${start}-${end}`
+  }
+  return plainRange
+}
+
+export function applyWinZipAesResponseHeaders(response, request) {
+  const { zipInfo, zipPlainRange } = request
+  if (!zipInfo || !zipPlainRange) return
+  if (response.statusCode >= 300 && response.statusCode < 400) return
+
+  if (zipPlainRange.hasRange) {
+    response.statusCode = 206
+    response.setHeader('content-range', `bytes ${zipPlainRange.start}-${zipPlainRange.end}/${zipInfo.plainSize}`)
+  } else if (response.statusCode < 300) {
+    response.statusCode = 200
+    response.removeHeader('content-range')
+  }
+  response.setHeader('accept-ranges', 'bytes')
+  response.setHeader('content-length', String(Math.max(0, zipPlainRange.end - zipPlainRange.start + 1)))
+  response.setHeader('content-type', getMimeByName(request.zipVirtualName || zipInfo.innerName || request.url))
+  response.removeHeader('content-encoding')
+  response.removeHeader('transfer-encoding')
+}
+
+class WinZipAesZip {
+  constructor(password, fileSize = 0, options = {}) {
+    this.password = password
+    this.plainSize = Number(fileSize) || 0
+    this.options = options || {}
+    this.zipInfo = this.options.zipInfo || null
+    this.passwdOutward = deriveOutwardPassword(password)
+    this.innerName = this.options.innerName || getInnerName(this.options.originalName || this.options.origName || INNER_FILENAME)
+    this.originalName = normalizeName(this.options.originalName || this.options.origName || this.innerName)
+    this.salt = this.zipInfo && this.zipInfo.salt ? Buffer.from(this.zipInfo.salt) : crypto.randomBytes(WINZIP_AES_SALT_SIZE)
+    this.strength = (this.zipInfo && this.zipInfo.winZipAes && this.zipInfo.winZipAes.strength) || WINZIP_AES_STRENGTH
+    this.keys = deriveWinZipAesKeys(password, this.salt, this.strength)
+    this.cipher = createWinZipAesCtr(this.keys.encKey, 0)
+    this.position = 0
+  }
+
+  static packageSize(plainSize, options = {}) {
+    return buildLayout({
+      plainSize: Number(plainSize) || 0,
+      originalName: options.originalName || options.origName || INNER_FILENAME,
+      innerName: options.innerName,
+    }).packageSize
+  }
+
+  static layout(plainSize, options = {}) {
+    return buildLayout({
+      plainSize: Number(plainSize) || 0,
+      originalName: options.originalName || options.origName || INNER_FILENAME,
+      innerName: options.innerName,
+    })
+  }
+
+  async setPositionAsync(position = 0) {
+    this.position = Number(position) || 0
+    if (this.zipInfo && this.zipInfo.salt) {
+      this.salt = Buffer.from(this.zipInfo.salt)
+      this.strength = (this.zipInfo.winZipAes && this.zipInfo.winZipAes.strength) || WINZIP_AES_STRENGTH
+      this.keys = deriveWinZipAesKeys(this.password, this.salt, this.strength)
+    }
+    this.cipher = createWinZipAesCtr(this.keys.encKey, this.position)
+  }
+
+  encryptTransform() {
+    const layout = buildLayout({
+      plainSize: this.plainSize,
+      originalName: this.originalName,
+      innerName: this.innerName,
+    })
+    let started = false
+    let written = 0
+    const cipher = createWinZipAesCtr(this.keys.encKey, 0)
+    const hmac = crypto.createHmac('sha1', this.keys.macKey)
+    const self = this
+
+    return new Transform({
+      transform(chunk, encoding, next) {
+        if (!started) {
+          this.push(layout.header)
+          this.push(self.salt)
+          this.push(self.keys.verifier)
+          started = true
+        }
+        const encrypted = cipher.update(chunk)
+        hmac.update(encrypted)
+        written += chunk.length
+        next(null, encrypted)
+      },
+      flush(next) {
+        if (!started) {
+          this.push(layout.header)
+          this.push(self.salt)
+          this.push(self.keys.verifier)
+        }
+        const final = cipher.final()
+        if (final.length) {
+          hmac.update(final)
+          this.push(final)
+        }
+        if (written !== self.plainSize) {
+          this.destroy(new Error('WinZip-AES-CTR ZIP upload size changed while streaming'))
+          return
+        }
+        this.push(hmac.digest().subarray(0, WINZIP_AES_AUTH_SIZE))
+        this.push(layout.central)
+        this.push(layout.endRecords)
+        next()
+      },
+    })
+  }
+
+  decryptTransform() {
+    const self = this
+    return new Transform({
+      transform(chunk, encoding, next) {
+        next(null, self.cipher.update(chunk))
+      },
+      flush(next) {
+        const final = self.cipher.final()
+        if (final.length) {
+          this.push(final)
+        }
+        next()
+      },
+    })
+  }
+}
+
+export default WinZipAesZip

--- a/node-proxy/src/utils/winZipAesZip.js
+++ b/node-proxy/src/utils/winZipAesZip.js
@@ -389,12 +389,21 @@ function parseRange(rangeHeader, totalSize) {
 function sanitizeForwardHeaders(headers = {}, options = {}) {
   const result = { ...headers }
   delete result.host
+  delete result.Host
   delete result.range
   delete result.Range
   delete result['content-length']
+  delete result['Content-Length']
   delete result['content-range']
+  delete result['Content-Range']
   delete result['transfer-encoding']
+  delete result['Transfer-Encoding']
   delete result['accept-encoding']
+  delete result['Accept-Encoding']
+  delete result['content-type']
+  delete result['Content-Type']
+  delete result.depth
+  delete result.Depth
   if (options.stripAuth) {
     delete result.authorization
     delete result.Authorization
@@ -409,10 +418,15 @@ function requestBuffer(urlAddr, options, redirectCount = 0) {
     const urlObj = new URL(urlAddr)
     const httpRequest = urlObj.protocol === 'https:' ? https : http
     const { maxBytes, ...requestOptions } = options
+    const headers = { ...(requestOptions.headers || {}) }
+    if (urlAddr.includes('baidupcs.com')) {
+      headers['User-Agent'] = 'pan.baidu.com'
+    }
     const req = httpRequest.request(
       urlObj,
       {
         ...requestOptions,
+        headers,
         rejectUnauthorized: false,
       },
       (resp) => {
@@ -420,10 +434,19 @@ function requestBuffer(urlAddr, options, redirectCount = 0) {
         if (resp.statusCode >= 300 && resp.statusCode < 400 && location && redirectCount < 5) {
           resp.resume()
           const nextUrl = new URL(location, urlObj).toString()
+          const nextUrlObj = new URL(nextUrl)
           const nextOptions = { ...options, headers: { ...(options.headers || {}) } }
           delete nextOptions.headers.host
-          delete nextOptions.headers.authorization
-          delete nextOptions.headers.referer
+          delete nextOptions.headers.Host
+          if (urlObj.host !== nextUrlObj.host) {
+            delete nextOptions.headers.authorization
+            delete nextOptions.headers.Authorization
+            delete nextOptions.headers.referer
+            delete nextOptions.headers.Referer
+          }
+          if (nextUrl.includes('baidupcs.com')) {
+            nextOptions.headers['User-Agent'] = 'pan.baidu.com'
+          }
           requestBuffer(nextUrl, nextOptions, redirectCount + 1).then(resolve).catch(reject)
           return
         }
@@ -687,7 +710,7 @@ export function serializeWinZipAesZipInfo(zipInfo) {
 }
 
 export function deserializeWinZipAesZipInfo(zipInfo) {
-  if (!zipInfo) return null
+  if (!zipInfo || !isWinZipAesEncType(zipInfo.encType)) return null
   return {
     ...zipInfo,
     salt: zipInfo.salt ? Buffer.from(zipInfo.salt, 'hex') : undefined,

--- a/node-proxy/src/utils/winZipAesZipCache.js
+++ b/node-proxy/src/utils/winZipAesZipCache.js
@@ -1,0 +1,130 @@
+import path from 'path'
+import { cacheFileInfo, getFileInfo } from '../dao/fileDao'
+import levelDB from './levelDB'
+import {
+  isWinZipAesEncType,
+  parseWinZipAesZipInfoFromRemote,
+  serializeWinZipAesZipInfo,
+} from './winZipAesZip'
+
+const NEGATIVE_CACHE_SECONDS = 10 * 60
+const PROBE_TABLE = 'winZipAesZipProbe_'
+const probeQueue = []
+const pendingKeys = new Set()
+let probing = false
+
+function normalizePath(filePath = '') {
+  return decodeURIComponent(filePath)
+}
+
+function normalizeSize(size) {
+  return Number(size) || 0
+}
+
+function probeKey(filePath) {
+  return PROBE_TABLE + normalizePath(filePath)
+}
+
+export function isUsableWinZipAesZipInfoCache(fileInfo, size) {
+  return !!(
+    fileInfo &&
+    fileInfo.zipInfo &&
+    isWinZipAesEncType(fileInfo.zipInfo.encType) &&
+    Number(fileInfo.size) === normalizeSize(size)
+  )
+}
+
+export function isUsableWinZipAesZipNegativeCache(probeInfo, size) {
+  return !!(
+    probeInfo &&
+    probeInfo.notPlayable &&
+    Number(probeInfo.size) === normalizeSize(size)
+  )
+}
+
+export async function getWinZipAesZipProbeCache(filePath, size) {
+  const cachedFileInfo = (await getFileInfo(filePath)) || (await getFileInfo(encodeURIComponent(filePath)))
+  if (isUsableWinZipAesZipInfoCache(cachedFileInfo, size)) {
+    return { type: 'hit', fileInfo: cachedFileInfo }
+  }
+  const negativeProbe = await levelDB.getValue(probeKey(filePath))
+  if (isUsableWinZipAesZipNegativeCache(negativeProbe, size)) {
+    return { type: 'negative', probeInfo: negativeProbe, fileInfo: cachedFileInfo }
+  }
+  return { type: 'miss', fileInfo: cachedFileInfo }
+}
+
+export async function cacheExternalWinZipAesZipInfo(fileInfo, zipInfo) {
+  const nextFileInfo = {
+    ...fileInfo,
+    path: normalizePath(fileInfo.path),
+    name: fileInfo.name || path.basename(fileInfo.path),
+    size: normalizeSize(fileInfo.size),
+    plainSize: zipInfo.plainSize,
+    zipInfo: serializeWinZipAesZipInfo(zipInfo),
+    externalZip: true,
+    zipVirtualName: fileInfo.zipVirtualName || fileInfo.name || path.basename(fileInfo.path),
+  }
+  await cacheFileInfo(nextFileInfo)
+  return nextFileInfo
+}
+
+export async function cacheExternalWinZipAesZipNegative(fileInfo, error) {
+  await levelDB.setExpire(
+    probeKey(fileInfo.path),
+    {
+      path: normalizePath(fileInfo.path),
+      size: normalizeSize(fileInfo.size),
+      notPlayable: true,
+      error: error && error.message ? error.message : String(error || ''),
+      updatedAt: Date.now(),
+    },
+    NEGATIVE_CACHE_SECONDS
+  )
+}
+
+async function processQueue() {
+  if (probing) return
+  probing = true
+  try {
+    while (probeQueue.length > 0) {
+      const job = probeQueue.shift()
+      const key = normalizePath(job.fileInfo.path)
+      try {
+        const cached = await getWinZipAesZipProbeCache(job.fileInfo.path, job.fileInfo.size)
+        if (cached.type === 'miss') {
+          const zipInfo = await parseWinZipAesZipInfoFromRemote(job.urlAddr, job.headers, job.fileInfo.size)
+          await cacheExternalWinZipAesZipInfo(job.fileInfo, zipInfo)
+        }
+      } catch (e) {
+        await cacheExternalWinZipAesZipNegative(job.fileInfo, e)
+      } finally {
+        pendingKeys.delete(key)
+      }
+    }
+  } finally {
+    probing = false
+  }
+}
+
+export function enqueueExternalWinZipAesZipProbe({ fileInfo, urlAddr, headers }) {
+  if (!fileInfo || fileInfo.is_dir || !String(fileInfo.name || '').toLowerCase().endsWith('.zip')) {
+    return false
+  }
+  const key = normalizePath(fileInfo.path)
+  if (!key || pendingKeys.has(key)) {
+    return false
+  }
+  pendingKeys.add(key)
+  probeQueue.push({
+    fileInfo: {
+      ...fileInfo,
+      path: normalizePath(fileInfo.path),
+      size: normalizeSize(fileInfo.size),
+    },
+    urlAddr,
+    headers: { ...(headers || {}) },
+  })
+  setTimeout(processQueue, 0)
+  return true
+}

--- a/node-proxy/src/utils/winZipAesZipCache.js
+++ b/node-proxy/src/utils/winZipAesZipCache.js
@@ -69,6 +69,21 @@ export async function cacheExternalWinZipAesZipInfo(fileInfo, zipInfo) {
   return nextFileInfo
 }
 
+export async function cacheManagedWinZipAesZipInfo(fileInfo, zipInfo) {
+  const nextFileInfo = {
+    ...fileInfo,
+    path: normalizePath(fileInfo.path),
+    name: fileInfo.name || path.basename(fileInfo.path),
+    size: normalizeSize(fileInfo.size),
+    plainSize: zipInfo.plainSize,
+    zipInfo: serializeWinZipAesZipInfo(zipInfo),
+    externalZip: false,
+    zipVirtualName: fileInfo.zipVirtualName,
+  }
+  await cacheFileInfo(nextFileInfo)
+  return nextFileInfo
+}
+
 export async function cacheExternalWinZipAesZipNegative(fileInfo, error) {
   await levelDB.setExpire(
     probeKey(fileInfo.path),

--- a/node-proxy/test/winZipAesZipTest.js
+++ b/node-proxy/test/winZipAesZipTest.js
@@ -19,6 +19,10 @@ import {
   prepareWinZipAesDownloadRequest,
   ZIP_AES_ENC_TYPE,
 } from '../src/utils/winZipAesZip'
+import {
+  isUsableWinZipAesZipInfoCache,
+  isUsableWinZipAesZipNegativeCache,
+} from '../src/utils/winZipAesZipCache'
 
 const password = 'admin123'
 
@@ -114,6 +118,10 @@ async function main() {
   assert.ok(isRawZipName(password, ZIP_AES_ENC_TYPE, 'abc.zip'))
   assert.ok(isRawZipName(password, ZIP_AES_ENC_TYPE, 'abc.mp4.zip'))
   assert.strictEqual(getAListFileTypeByName('电影.final 4k.mp4'), 2)
+  assert.ok(isUsableWinZipAesZipInfoCache({ size: 123, zipInfo: { encType: ZIP_AES_ENC_TYPE } }, 123))
+  assert.ok(!isUsableWinZipAesZipInfoCache({ size: 124, zipInfo: { encType: ZIP_AES_ENC_TYPE } }, 123))
+  assert.ok(isUsableWinZipAesZipNegativeCache({ size: 123, notPlayable: true }, 123))
+  assert.ok(!isUsableWinZipAesZipNegativeCache({ size: 124, notPlayable: true }, 123))
 
   const plain = Buffer.concat([Buffer.from('ftypisom'), crypto.randomBytes(512 * 1024 + 37), Buffer.from('zip aes tail')])
   const { zipPath } = await createZip(plain)

--- a/node-proxy/test/winZipAesZipTest.js
+++ b/node-proxy/test/winZipAesZipTest.js
@@ -1,0 +1,142 @@
+import assert from 'assert'
+import crypto from 'crypto'
+import childProcess from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { pipeline } from 'stream/promises'
+import WinZipAesZip from '../src/utils/winZipAesZip'
+import {
+  isWinZipAesEncType,
+  parseWinZipAesZipInfoFromFile,
+  prepareWinZipAesDownloadRequest,
+  ZIP_AES_ENC_TYPE,
+} from '../src/utils/winZipAesZip'
+
+const password = 'admin123'
+
+function readFileRange(filePath, start, end) {
+  const fd = fs.openSync(filePath, 'r')
+  try {
+    const length = end - start + 1
+    const buffer = Buffer.alloc(length)
+    const bytesRead = fs.readSync(fd, buffer, 0, length, start)
+    return buffer.subarray(0, bytesRead)
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
+async function createZip(plain, originalName = 'video.final.mp4') {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alist-wz-aes-'))
+  const plainPath = path.join(tempDir, originalName)
+  const zipPath = path.join(tempDir, `${originalName}.zip`)
+  fs.writeFileSync(plainPath, plain)
+  const zipEnc = new WinZipAesZip(password, plain.length, { originalName })
+  await pipeline(fs.createReadStream(plainPath), zipEnc.encryptTransform(), fs.createWriteStream(zipPath))
+  return { tempDir, plainPath, zipPath }
+}
+
+function createExternalZip(plain, originalName = 'external.video.mp4') {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alist-wz-aes-external-'))
+  const plainPath = path.join(tempDir, originalName)
+  const zipPath = path.join(tempDir, `${originalName}.zip`)
+  fs.writeFileSync(plainPath, plain)
+  const pyCreate = [
+    'import pathlib, pyzipper, sys',
+    'plain_path = pathlib.Path(sys.argv[1])',
+    'zip_path = pathlib.Path(sys.argv[2])',
+    'with pyzipper.AESZipFile(zip_path, "w", compression=pyzipper.ZIP_STORED, encryption=pyzipper.WZ_AES) as zf:',
+    "    zf.setpassword(b'admin123')",
+    '    zf.setencryption(pyzipper.WZ_AES, nbits=256)',
+    '    zf.write(plain_path, arcname=plain_path.name)',
+  ].join('\n')
+  childProcess.execFileSync('python', ['-c', pyCreate, plainPath, zipPath])
+  return { tempDir, plainPath, zipPath }
+}
+
+async function decryptRange(zipPath, rangeHeader) {
+  const zipInfo = await parseWinZipAesZipInfoFromFile(zipPath)
+  const request = { method: 'GET', headers: {}, url: '/video.final.mp4', zipVirtualName: 'video.final.mp4' }
+  prepareWinZipAesDownloadRequest(request, zipInfo, rangeHeader)
+  const encrypted = readFileRange(zipPath, request.zipPackageRange.start, request.zipPackageRange.end)
+  const zipEnc = new WinZipAesZip(password, zipInfo.plainSize, { zipInfo })
+  await zipEnc.setPositionAsync(request.zipCipherStart)
+  const chunks = []
+  await pipeline(
+    async function* () {
+      yield encrypted
+    },
+    zipEnc.decryptTransform(),
+    async function* (source) {
+      for await (const chunk of source) {
+        chunks.push(chunk)
+      }
+    }
+  )
+  return Buffer.concat(chunks)
+}
+
+async function assertRanges(zipPath, plain) {
+  const full = await decryptRange(zipPath)
+  assert.deepStrictEqual(full, plain)
+
+  const suffix = await decryptRange(zipPath, 'bytes=-1024')
+  assert.deepStrictEqual(suffix, plain.subarray(plain.length - 1024))
+
+  const ranges = [
+    [0, 63],
+    [7, 4095],
+    [Math.floor(plain.length / 2) - 13, Math.floor(plain.length / 2) + 1024],
+    [plain.length - 2048, plain.length - 1],
+  ]
+  for (const [start, end] of ranges) {
+    const actual = await decryptRange(zipPath, `bytes=${start}-${end}`)
+    assert.deepStrictEqual(actual, plain.subarray(start, end + 1), `range ${start}-${end}`)
+  }
+}
+
+async function main() {
+  assert.ok(isWinZipAesEncType(ZIP_AES_ENC_TYPE))
+  const plain = Buffer.concat([Buffer.from('ftypisom'), crypto.randomBytes(512 * 1024 + 37), Buffer.from('zip aes tail')])
+  const { zipPath } = await createZip(plain)
+  const zipInfo = await parseWinZipAesZipInfoFromFile(zipPath)
+
+  assert.strictEqual(zipInfo.encType, ZIP_AES_ENC_TYPE)
+  assert.strictEqual(zipInfo.innerName, 'payload.mp4')
+  assert.strictEqual(zipInfo.plainSize, plain.length)
+  assert.strictEqual(zipInfo.winZipAes.actualMethod, 0)
+  assert.strictEqual(zipInfo.winZipAes.strength, 3)
+  assert.strictEqual(zipInfo.salt.length, 16)
+  assert.strictEqual(zipInfo.compressedSize, plain.length + 28)
+
+  const pyCheck = [
+    'import pathlib, pyzipper, sys',
+    'zip_path = pathlib.Path(sys.argv[1])',
+    'with pyzipper.AESZipFile(zip_path) as zf:',
+    "    zf.setpassword(b'admin123')",
+    '    names = zf.namelist()',
+    '    assert names == ["payload.mp4"], names',
+    '    data = zf.read(names[0])',
+    '    sys.stdout.buffer.write(data)',
+  ].join('\n')
+  const unzipped = childProcess.execFileSync('python', ['-c', pyCheck, zipPath], { maxBuffer: plain.length + 1024 })
+  assert.deepStrictEqual(unzipped, plain)
+
+  await assertRanges(zipPath, plain)
+
+  const externalPlain = Buffer.concat([Buffer.from('ftypmp42'), crypto.randomBytes(128 * 1024 + 31), Buffer.from('external zip aes')])
+  const external = createExternalZip(externalPlain)
+  const externalZipInfo = await parseWinZipAesZipInfoFromFile(external.zipPath)
+  assert.strictEqual(externalZipInfo.innerName, 'external.video.mp4')
+  assert.strictEqual(externalZipInfo.plainSize, externalPlain.length)
+  assert.strictEqual(externalZipInfo.winZipAes.actualMethod, 0)
+  await assertRanges(external.zipPath, externalPlain)
+
+  console.log('winZipAesZipTest ok')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/node-proxy/test/winZipAesZipTest.js
+++ b/node-proxy/test/winZipAesZipTest.js
@@ -7,6 +7,13 @@ import path from 'path'
 import { pipeline } from 'stream/promises'
 import WinZipAesZip from '../src/utils/winZipAesZip'
 import {
+  convertRealName,
+  convertShowName,
+  getAListFileTypeByName,
+  isEncryptedZipName,
+  isRawZipName,
+} from '../src/utils/commonUtil'
+import {
   isWinZipAesEncType,
   parseWinZipAesZipInfoFromFile,
   prepareWinZipAesDownloadRequest,
@@ -98,6 +105,15 @@ async function assertRanges(zipPath, plain) {
 
 async function main() {
   assert.ok(isWinZipAesEncType(ZIP_AES_ENC_TYPE))
+  const encryptedName = convertRealName(password, ZIP_AES_ENC_TYPE, '电影.final 4k.mp4')
+  assert.ok(encryptedName.endsWith('.zip'))
+  assert.ok(!encryptedName.endsWith('.mp4.zip'))
+  assert.strictEqual(convertShowName(password, ZIP_AES_ENC_TYPE, encryptedName), '电影.final 4k.mp4')
+  assert.ok(isEncryptedZipName(password, ZIP_AES_ENC_TYPE, encryptedName))
+  assert.ok(isRawZipName(password, ZIP_AES_ENC_TYPE, 'abc.zip'))
+  assert.ok(isRawZipName(password, ZIP_AES_ENC_TYPE, 'abc.mp4.zip'))
+  assert.strictEqual(getAListFileTypeByName('电影.final 4k.mp4'), 2)
+
   const plain = Buffer.concat([Buffer.from('ftypisom'), crypto.randomBytes(512 * 1024 + 37), Buffer.from('zip aes tail')])
   const { zipPath } = await createZip(plain)
   const zipInfo = await parseWinZipAesZipInfoFromFile(zipPath)

--- a/node-proxy/test/winZipAesZipTest.js
+++ b/node-proxy/test/winZipAesZipTest.js
@@ -15,6 +15,7 @@ import {
 } from '../src/utils/commonUtil'
 import {
   isWinZipAesEncType,
+  parseManagedWinZipAesZipInfoFromFile,
   parseWinZipAesZipInfoFromFile,
   prepareWinZipAesDownloadRequest,
   ZIP_AES_ENC_TYPE,
@@ -126,6 +127,7 @@ async function main() {
   const plain = Buffer.concat([Buffer.from('ftypisom'), crypto.randomBytes(512 * 1024 + 37), Buffer.from('zip aes tail')])
   const { zipPath } = await createZip(plain)
   const zipInfo = await parseWinZipAesZipInfoFromFile(zipPath)
+  const managedZipInfo = await parseManagedWinZipAesZipInfoFromFile(zipPath)
 
   assert.strictEqual(zipInfo.encType, ZIP_AES_ENC_TYPE)
   assert.strictEqual(zipInfo.innerName, 'payload.mp4')
@@ -134,6 +136,11 @@ async function main() {
   assert.strictEqual(zipInfo.winZipAes.strength, 3)
   assert.strictEqual(zipInfo.salt.length, 16)
   assert.strictEqual(zipInfo.compressedSize, plain.length + 28)
+  assert.strictEqual(managedZipInfo.innerName, zipInfo.innerName)
+  assert.strictEqual(managedZipInfo.plainSize, zipInfo.plainSize)
+  assert.strictEqual(managedZipInfo.payloadOffset, zipInfo.payloadOffset)
+  assert.strictEqual(managedZipInfo.authTagOffset, zipInfo.authTagOffset)
+  assert.deepStrictEqual(managedZipInfo.salt, zipInfo.salt)
 
   const pyCheck = [
     'import pathlib, pyzipper, sys',

--- a/node-proxy/test/winZipAesZipTest.js
+++ b/node-proxy/test/winZipAesZipTest.js
@@ -110,6 +110,7 @@ async function main() {
   assert.ok(!encryptedName.endsWith('.mp4.zip'))
   assert.strictEqual(convertShowName(password, ZIP_AES_ENC_TYPE, encryptedName), '电影.final 4k.mp4')
   assert.ok(isEncryptedZipName(password, ZIP_AES_ENC_TYPE, encryptedName))
+  assert.ok(!isRawZipName(password, ZIP_AES_ENC_TYPE, encryptedName))
   assert.ok(isRawZipName(password, ZIP_AES_ENC_TYPE, 'abc.zip'))
   assert.ok(isRawZipName(password, ZIP_AES_ENC_TYPE, 'abc.mp4.zip'))
   assert.strictEqual(getAListFileTypeByName('电影.final 4k.mp4'), 2)


### PR DESCRIPTION
## 这个 PR 做什么

新增一种算法：`winzip-aes-ctr`。

命中该算法的路径上传文件时，会把原文件包装成标准单文件 WinZip AES ZIP：

- ZIP 使用 Store，不压缩，方便把播放器 Range 映射到 ZIP 内部 payload。
- 加密使用 WinZip AES 标准字段，7-Zip、WinRAR 等常规解压软件输入密码后可以解出正常文件。
- 受管文件的 raw 存储名为 `加密后的完整原文件名.zip`，例如 `视频.mp4` 不再存成 `.mp4.zip`，raw 侧不暴露原扩展名。
- ZIP 内部文件名为 `payload.ext`，例如 `payload.mp4`，保证解压出来能直接播放，同时不暴露原标题。
- 在线播放时不缓存整个视频，只解析 ZIP 字段，按 Range 读取 payload 密文区并流式解密。

未命中 `winzip-aes-ctr` 的路径继续走原来的 `aesctr`、`rc4` 等逻辑。

## ZIP 识别方式

受管文件：

- 文件名必须是 `.zip`。
- `.zip` 前面的部分能用当前路径密码和 `winzip-aes-ctr` 解出完整原文件名。
- 代理列表显示解密后的原名，raw AList 仍只看到加密名加 `.zip`。

外部压缩软件制作的 ZIP：

- 例如 7-Zip、WinRAR 选择 WinZip AES、仅存储/不压缩、密码加密后得到的 `abc.zip` 或 `abc.mp4.zip`。
- 默认不会在目录列表阶段解析这类外部 ZIP，列表里仍按普通 ZIP 显示，避免打开文件夹就批量读取 ZIP 头尾字段。
- 用户点击具体 `abc.zip` 时才懒识别；命中后本次详情页按内部文件类型播放，不命中就保持普通 ZIP 下载页。
- 如果配置里显式开启 `zipAutoCache`，列表请求只把外部 ZIP 放入低优先级后台队列，后台单并发探测并写缓存，列表响应本身不等待、不改名、不改 type。
- 内部文件名只用于判断类型、MIME 和 Range 播放，例如内部是 `电影.mp4` 时按视频处理。

是否可播放不只看文件名。代码会解析 ZIP 原生字段，并且同时满足这些条件才按可播放 ZIP 处理：

- EOCD / central directory 显示只有一个 entry。
- entry 带加密标志。
- ZIP method 是 WinZip AES method `99`。
- 存在标准 WinZip AES extra field `0x9901`，vendor 为 `AE`。
- AES extra field 里的 actual method 是 Store `0`。
- `compressed size = plain size + salt + password verifier + auth code`，确认是可直接 Range 映射的 Store AES 数据。

普通 ZIP、多文件 ZIP、非 WinZip AES、或压缩方式不是 Store 的 ZIP 会保持普通 ZIP 处理，不进入在线播放解密逻辑；失败探测会写短期 negative cache，避免同一个普通 ZIP 被反复探测。

## 主要代码位置

- `node-proxy/src/utils/winZipAesZip.js`
  - 生成和解析 WinZip AES ZIP。
  - 解析 EOCD、ZIP64、central directory、local header、AES extra field。
  - 计算 `payloadOffset`，把明文 Range 映射到 ZIP payload 密文 Range。
  - 重写响应头，让播放器看到明文 `content-range`、`content-length`、`content-type`。

- `node-proxy/src/utils/winZipAesZipCache.js`
  - 外部 ZIP 懒识别缓存、negative cache 和可选后台探测队列。
  - 缓存用真实 ZIP size 校验，size 变化后重新探测。

- `node-proxy/src/utils/flowEnc.js`
  - 接入新的 `winzip-aes-ctr` 类型。
  - 上传时输出 ZIP 包装流，下载时输出 AES-CTR 解密流。

- `node-proxy/app.js`
  - `/api/fs/get` 点击文件时懒识别外部 ZIP，命中后返回明文大小和代理 raw_url。
  - `/redirect/:key` 和下载代理按 Range 解密返回。
  - WebDAV GET / HEAD 命中时返回明文媒体流。

- `node-proxy/src/encNameRouter.js`
  - AList API 的列表、详情、上传、下载、重命名、移动/复制文件名映射。
  - 受管 `.zip` 在列表中恢复原名；外部 raw `.zip` 默认列表不解析，只在 `zipAutoCache` 开启时入队。

- `node-proxy/src/encDavHandle.js`
  - WebDAV PROPFIND 显示虚拟文件名和明文大小。
  - 外部 ZIP 的 PROPFIND 默认不解析；GET / HEAD 时再懒识别。

- `node-proxy/src/dao/fileDao.js`
  - 列表缓存刷新时保留同 size 的 ZIP 字段缓存，避免已解析信息被普通列表覆盖。

- `node-proxy/src/utils/commonUtil.ts`
  - `convertRealName()` / `convertShowName()` 的 WinZip AES 文件名映射。
  - `isEncryptedZipName()` / `isRawZipName()` 区分受管文件和外部 ZIP。
  - `getAListFileTypeByName()` 用虚拟名或内部名还原 AList 类型。

- `enc-webui/src/views/setting-alist/index.vue`
- `enc-webui/src/views/setting-webdav/index.vue`
  - 设置页增加 `WinZip-AES-CTR` 选项，配置值为 `winzip-aes-ctr`。
  - WinZip-AES-CTR 下增加 `ZIP缓存` 开关，保存到 `zipAutoCache`，默认关闭。

- `node-proxy/test/winZipAesZipTest.js`
  - 覆盖受管文件名隐藏、ZIP 字段解析、Range 解密、pyzipper/外部 WinZip AES Store ZIP 兼容、缓存 size 校验。

## 性能测试

测试口径：从 `/api/fs/get` 开始计时，到 `raw_url` 的 `Range: bytes=0-31` 真正拿到包含 `ftyp` 的视频字节为止。每个视频 10 次，每次间隔 10 秒。

| 文件 | ZIP字段缓存 | 总平均 | `/api/fs/get` 平均 | Range 拿到视频字节平均 | min / max |
| --- | --- | ---: | ---: | ---: | ---: |
| `1920-1080-4205-h264.mp4` | 开 | 1.448s | 0.029s | 1.418s | 0.835 / 4.811s |
| `2026-01-08 17-59-30.mp4` | 开 | 1.037s | 0.024s | 1.012s | 0.811 / 1.412s |
| `1920-1080-4205-h264.mp4` | 关 | 1.861s | 0.947s | 0.913s | 1.624 / 2.110s |
| `2026-01-08 17-59-30.mp4` | 关 | 2.018s | 1.029s | 0.988s | 1.663 / 3.511s |

结果：受管 WinZip AES ZIP 开启 `zipInfoCache` 后，`/api/fs/get` 不再重复解析 ZIP 字段，从约 0.95s - 1.03s 降到约 0.02s - 0.03s。总耗时主要剩远端 Range 请求；以上请求均返回 `206`，首段都包含 `ftyp`。

## 验证
本地已验证：

```bash
npm exec -- ts-node -r tsconfig-paths/register test/winZipAesZipTest.js
git diff --check
npm run webpack
```

结果：

- `winZipAesZipTest ok`
- `git diff --check` 通过
- `npm run webpack` 通过，仅有原项目 log4js 动态依赖 warning

也做过本地手动验证：

- raw AList 只显示加密后的 `.zip`。
- 代理列表显示原始 `.mp4`。
- 网页播放 Range 返回 `206 video/mp4`，首段包含 `ftyp`。
- WebDAV PROPFIND 显示明文大小，GET Range 返回可播放 MP4 数据。
